### PR TITLE
41 async events get logged as instances

### DIFF
--- a/agentops/llm_tracker.py
+++ b/agentops/llm_tracker.py
@@ -46,6 +46,8 @@ class LlmTracker:
 
                 if finish_reason:
                     self.event_stream.returns['finish_reason'] = finish_reason
+                    # Update end_timestamp
+                    self.event_stream.end_timestamp = get_ISO_time()
                     self.client.record(self.event_stream)
                     self.event_stream = None
             except:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" }

--- a/tests/async_call_agent.py
+++ b/tests/async_call_agent.py
@@ -1,12 +1,13 @@
+
+import openai
 import agentops
 import asyncio
-import openai
+import os
 
 ao_client = agentops.Client(api_key='',
                             tags=['mock tests'])
 
-
-openai.api_key = '3'
+openai.api_key = os.environ['OPENAI_API_KEY']
 
 
 async def stream_achat():


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
-Fixed async events showing as instant events instead of creating an end_timestamp upon completion
-Fixed openai streaming timestamps to append end_timestamp upon completion

