### PR TITLE
Add support for org keys

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -56,10 +56,8 @@ class Client:
         if org_key is None:
             org_key = environ.get('AGENTOPS_ORG_KEY')
 
-        self.org_key = org_key
-
         # Create a worker config
-        self.config = Configuration(api_key, endpoint,
+        self.config = Configuration(api_key, org_key, endpoint,
                                     max_wait_time, max_queue_size)
 
         # Store a reference to the instance
@@ -116,7 +114,7 @@ class Client:
 
         if not self.session.has_ended:
             self.worker.add_event(
-                {'session_id': self.session.session_id, 'org_key': self.org_key, **event.__dict__})
+                {'session_id': self.session.session_id, **event.__dict__})
         else:
             logging.info("This event was not recorded because the previous session has been ended" +
                          " Start a new session to record again.")

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -116,7 +116,7 @@ class Client:
 
         if not self.session.has_ended:
             self.worker.add_event(
-                {'session_id': self.session.session_id, 'orgKey': self.org_key, **event.__dict__})
+                {'session_id': self.session.session_id, 'org_key': self.org_key, **event.__dict__})
         else:
             logging.info("This event was not recorded because the previous session has been ended" +
                          " Start a new session to record again.")

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -59,7 +59,7 @@ class Configuration:
         """
         return self._org_key
 
-    @api_key.setter
+    @org_key.setter
     def org_key(self, value: str):
         """
         Set the API Key for AgentOps services.

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -14,14 +14,17 @@ class Configuration:
 
     Args:
         api_key (str, optional): API Key for AgentOps services
+        org_key (str, optional): Allows sessions/events analytics to be tracked by the owners of the organization key.
         endpoint (str, optional): The endpoint for the AgentOps service. Defaults to 'https://agentops-server-v2.fly.dev'.
         max_wait_time (int, optional): The maximum time to wait in milliseconds before flushing the queue. Defaults to 1000.
         max_queue_size (int, optional): The maximum size of the event queue. Defaults to 100.
     """
 
-    def __init__(self, api_key: Optional[str] = None, endpoint: Optional[str] = 'https://agentops-server-v2.fly.dev',
+    def __init__(self, api_key: Optional[str] = None, org_key: Optional[str] = None,
+                 endpoint: Optional[str] = 'https://agentops-server-v2.fly.dev',
                  max_wait_time: Optional[int] = 1000, max_queue_size: Optional[int] = 100):
         self._api_key: str | None = api_key
+        self._org_key: str | None = org_key
         self._endpoint = endpoint
         self._max_wait_time = max_wait_time
         self._max_queue_size = max_queue_size
@@ -45,6 +48,26 @@ class Configuration:
             value (str): The new API Key.
         """
         self._api_key = value
+
+    @property
+    def org_key(self) -> str:
+        """
+        Get the API Key for AgentOps services.
+
+        Returns:
+            str: The API Key for AgentOps services.
+        """
+        return self._org_key
+
+    @api_key.setter
+    def org_key(self, value: str):
+        """
+        Set the API Key for AgentOps services.
+
+        Args:
+            value (str): The new API Key.
+        """
+        self._org_key = value
 
     @property
     def endpoint(self) -> str:

--- a/agentops/http.py
+++ b/agentops/http.py
@@ -58,7 +58,7 @@ class Response:
 class HttpClient:
 
     @staticmethod
-    def post(url: str, payload: bytes, api_key: str = None, header=None) -> Response:
+    def post(url: str, payload: bytes, api_key: str = None, org_key: str = None, header=None) -> Response:
         result = Response()
         try:
             # Create request session with retries configured
@@ -67,6 +67,9 @@ class HttpClient:
 
             if api_key != None:
                 JSON_HEADER["X-Agentops-Auth"] = api_key
+
+            if org_key != None:
+                JSON_HEADER["X-Agentops-Org"] = org_key
 
             res = request_session.post(url, data=payload,
                                        headers=JSON_HEADER, timeout=20)

--- a/agentops/http.py
+++ b/agentops/http.py
@@ -58,7 +58,7 @@ class Response:
 class HttpClient:
 
     @staticmethod
-    def post(url: str, payload: bytes, api_key: str = None, org_key: str = None, header=None) -> Response:
+    def post(url: str, payload: bytes, api_key: str = None, org_key: Optional[str] = None, header=None) -> Response:
         result = Response()
         try:
             # Create request session with retries configured

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -23,10 +23,11 @@ class Session:
 
     """
 
-    def __init__(self, session_id: str, tags: Optional[List[str]] = None):
+    def __init__(self, session_id: str, tags: Optional[List[str]] = None, org_key: Optional[str] = None):
         self.session_id = session_id
         self.init_timestamp = get_ISO_time()
         self.tags = tags
+        self.org_key = org_key
 
     def end_session(self, end_state: str = "Indeterminate", rating: Optional[str] = None):
         """

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -23,11 +23,10 @@ class Session:
 
     """
 
-    def __init__(self, session_id: str, tags: Optional[List[str]] = None, org_key: Optional[str] = None):
+    def __init__(self, session_id: str, tags: Optional[List[str]] = None):
         self.session_id = session_id
         self.init_timestamp = get_ISO_time()
         self.tags = tags
-        self.org_key = org_key
 
     def end_session(self, end_state: str = "Indeterminate", rating: Optional[str] = None):
         """

--- a/agentops/worker.py
+++ b/agentops/worker.py
@@ -62,7 +62,8 @@ class Worker:
                     safe_serialize(payload).encode("utf-8")
                 HttpClient.post(f'{self.config.endpoint}/events',
                                 serialized_payload,
-                                self.config.api_key)
+                                self.config.api_key,
+                                self.config.org_key)
 
     def start_session(self, session: Session) -> None:
         with self.lock:
@@ -88,7 +89,8 @@ class Worker:
             HttpClient.post(f'{self.config.endpoint}/sessions',
                             json.dumps(filter_unjsonable(
                                 payload)).encode("utf-8"),
-                            self.config.api_key)
+                            self.config.api_key,
+                            self.config.org_key)
 
     def run(self) -> None:
         while not self.stop_flag.is_set():

--- a/agentops/worker.py
+++ b/agentops/worker.py
@@ -74,7 +74,8 @@ class Worker:
                 json.dumps(filter_unjsonable(payload)).encode("utf-8")
             HttpClient.post(f'{self.config.endpoint}/sessions',
                             serialized_payload,
-                            self.config.api_key)
+                            self.config.api_key,
+                            self.config.org_key)
 
     def end_session(self, session: Session) -> None:
         self.stop_flag.set()


### PR DESCRIPTION
Adds org_key to config. Worker and HttpClient then adds X-AgentOps-Org to the request headers