### PR TITLE
Adding support for screenshots and video

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -245,19 +245,22 @@ class Client:
         self.worker.start_session(self.session)
 
     def end_session(self, end_state: str = Field("Indeterminate",
-                                                 description="End state of the session",
-                                                 pattern="^(Success|Fail|Indeterminate)$"),
-                    rating: Optional[str] = None):
+                                                description="End state of the session",
+                                                pattern="^(Success|Fail|Indeterminate)$"),
+                                                rating: Optional[str] = None,
+                                                video: Optional[str] = None):
         """
         End the current session with the AgentOps service.
 
         Args:
             end_state (str, optional): The final state of the session.
             rating (str, optional): The rating for the session.
+            video (str, optional): The video screen recording of the session
         """
         if not self.session.has_ended:
             self.session.end_session(end_state, rating)
             self.worker.end_session(self.session)
+            self.session.video = video
         else:
             logging.info("Warning: The session has already been ended.")
 

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -26,7 +26,7 @@ class Event:
         tags (List[str], optional): Tags that can be used for grouping or sorting later. e.g. ["my_tag"]. Defaults to None.
         init_timestamp (float, optional): The timestamp for when the event was initiated, represented as seconds since the epoch.
                 Defaults to the end timestamp.
-        screenshot (str, optional): A screenshot of the webapage at the time of the event. Base64 string or URL. Defaults to None.
+        screenshot (str, optional): A screenshot of the webpage at the time of the event. Base64 string or URL. Defaults to None.
 
     Attributes:
         event_type (str): Type of the event.

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -7,7 +7,7 @@ Classes:
 from .helpers import get_ISO_time, Models
 from typing import Optional, List
 from pydantic import Field
-
+from PIL import Image
 
 class Event:
     """
@@ -18,7 +18,7 @@ class Event:
         params (str, optional): The parameters passed to the operation.
         returns (str, optional): The output of the operation.
         result (str, optional): Result of the operation, e.g., "Success", "Fail", "Indeterminate". Defaults to "Indeterminate".
-        action_type (str, optional): Type of action of the event e.g. 'action', 'llm', 'api'. Defaults to 'action'.
+        action_type (str, optional): Type of action of the event e.g. 'action', 'llm', 'api', 'screenshot'. Defaults to 'action'.
         model (Models, optional): The model used during the event if an LLM is used (i.e. GPT-4).
                 For models, see the types available in the Models enum. 
                 If a model is set but an action_type is not, the action_type will be coerced to 'llm'. 
@@ -27,6 +27,7 @@ class Event:
         tags (List[str], optional): Tags that can be used for grouping or sorting later. e.g. ["my_tag"]. Defaults to None.
         init_timestamp (float, optional): The timestamp for when the event was initiated, represented as seconds since the epoch.
                 Defaults to the end timestamp.
+        screenshot: A screenshot of the webapage at the time of the event
 
     Attributes:
         event_type (str): Type of the event.
@@ -49,11 +50,12 @@ class Event:
                                      pattern="^(Success|Fail|Indeterminate)$"),
                  action_type: Optional[str] = Field("action",
                                                     description="Type of action that the user is recording",
-                                                    pattern="^(action|api|llm)$"),
+                                                    pattern="^(action|api|llm|screenshot)$"),
                  model: Optional[Models] = None,
                  prompt: Optional[str] = None,
                  tags: Optional[List[str]] = None,
-                 init_timestamp: Optional[float] = None
+                 init_timestamp: Optional[float] = None,
+                 screenshot: Optional[Image.Image] = None
                  ):
         self.event_type = event_type
         self.params = params
@@ -65,3 +67,4 @@ class Event:
         self.prompt = prompt
         self.end_timestamp = get_ISO_time()
         self.init_timestamp = init_timestamp if init_timestamp else self.end_timestamp
+        self.screenshot = screenshot

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -26,7 +26,7 @@ class Event:
         tags (List[str], optional): Tags that can be used for grouping or sorting later. e.g. ["my_tag"]. Defaults to None.
         init_timestamp (float, optional): The timestamp for when the event was initiated, represented as seconds since the epoch.
                 Defaults to the end timestamp.
-        screenshot (str, optional): A screenshot of the webapage at the time of the event. Base64 string
+        screenshot (str, optional): A screenshot of the webapage at the time of the event. Base64 string or URL. Defaults to None.
 
     Attributes:
         event_type (str): Type of the event.

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -7,7 +7,6 @@ Classes:
 from .helpers import get_ISO_time, Models
 from typing import Optional, List
 from pydantic import Field
-from PIL import Image
 
 class Event:
     """
@@ -27,7 +26,7 @@ class Event:
         tags (List[str], optional): Tags that can be used for grouping or sorting later. e.g. ["my_tag"]. Defaults to None.
         init_timestamp (float, optional): The timestamp for when the event was initiated, represented as seconds since the epoch.
                 Defaults to the end timestamp.
-        screenshot: A screenshot of the webapage at the time of the event
+        screenshot (str, optional): A screenshot of the webapage at the time of the event. Base64 string
 
     Attributes:
         event_type (str): Type of the event.
@@ -55,7 +54,7 @@ class Event:
                  prompt: Optional[str] = None,
                  tags: Optional[List[str]] = None,
                  init_timestamp: Optional[float] = None,
-                 screenshot: Optional[Image.Image] = None
+                 screenshot: Optional[str] = None
                  ):
         self.event_type = event_type
         self.params = params

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -27,10 +27,6 @@ class Session:
         self.session_id = session_id
         self.init_timestamp = get_ISO_time()
         self.tags = tags
-        self.video = None
-
-    def add_video_recording(self, video):
-        self.video = video
 
     def end_session(self, end_state: str = "Indeterminate", rating: Optional[str] = None):
         """

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -27,6 +27,10 @@ class Session:
         self.session_id = session_id
         self.init_timestamp = get_ISO_time()
         self.tags = tags
+        self.video = None
+
+    def add_video_recording(self, video):
+        self.video = video
 
     def end_session(self, end_state: str = "Indeterminate", rating: Optional[str] = None):
         """


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Adding support for event screenshots and session videos

**🔄 Related Issue (if applicable)**
N/A

**🎯 Goal**
Adding screenshot and video members to the Event and Session classes respectively so that we may capture screenshots of events (e.g. snapshot of web page) and videos of sessions (e.g. screen recording of web journey)

**🔍 Additional Context**
First integration will be the MultiOn API
Screenshot: string (e.g. base64, url)
Video: string (e.g. url)

**🧪 Testing**
Run MultiOn Jupyter examples with new_session/update_session() and get_video()
