### PR TITLE
optionally bypass create new session on client init

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -129,7 +129,7 @@ class Client:
             event (Event): The event to record.
         """
 
-        if not self._session is None and not self._session.has_ended:
+        if not self._session is None:
             self._worker.add_event(
                 {'session_id': self._session.session_id, **event.__dict__})
         else:
@@ -301,16 +301,14 @@ class Client:
         """
         if self._session is None:
             return print("Session has already been ended.")
-        if not self._session.has_ended:
-            self._session.video = video
-            self._session.end_session(end_state, rating, end_state_reason)
-            self._worker.end_session(self._session)
-            # self._session = None
-        else:
-            logging.info("Warning: The session has already been ended.")
+
+        self._session.video = video
+        self._session.end_session(end_state, rating, end_state_reason)
+        self._worker.end_session(self._session)
+        # self._session = None
 
     def cleanup(self, end_state_reason: Optional[str] = None):
         # Only run cleanup function if session is created
-        if hasattr(self, "session") and not self._session.has_ended:
+        if hasattr(self, "session"):
             self.end_session(end_state='Fail',
                              end_state_reason=end_state_reason)

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -76,10 +76,10 @@ class Client:
         # Override sys.excepthook
         sys.excepthook = self.handle_exception
 
+        self._session = None
         if not bypass_new_session:
             self.start_session(tags)
         else:
-            self._session = None
             self._worker = None
             self._tags = tags
 

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -274,6 +274,9 @@ class Client:
             tags (List[str], optional): Tags that can be used for grouping or sorting later.
                 e.g. ["test_run"].
         """
+        if self.session is not None:
+            return print("Session already started. End this session before starting a new one.")
+
         self.session = Session(str(uuid4()), tags)
         self.worker = Worker(self.config)
         self.worker.start_session(self.session)
@@ -294,9 +297,10 @@ class Client:
             video (str, optional): The video screen recording of the session
         """
         if not self.session.has_ended:
+            self.session.video = video
             self.session.end_session(end_state, rating, end_state_reason)
             self.worker.end_session(self.session)
-            self.session.video = video
+            self.session = None
         else:
             logging.info("Warning: The session has already been ended.")
 

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -121,6 +121,26 @@ class Client:
                          end_state_reason=f'Signal {signal_name} detected')
         sys.exit(0)
 
+    def add_tags(self, tags: List[str]):
+        if self._session is None:
+            return print("You must create a session before assigning tags")
+
+        if self._tags is not None:
+            self._tags.extend(tags)
+        else:
+            self._tags = tags
+
+        self._session.tags = self._tags
+        self._worker.update_session(self._session)
+
+    def set_tags(self, tags: List[str]):
+        if self._session is None:
+            return print("You must create a session before assigning tags")
+
+        self._tags = tags
+        self._session.tags = tags
+        self._worker.update_session(self._session)
+
     def record(self, event: Event):
         """
         Record an event with the AgentOps service.
@@ -129,7 +149,7 @@ class Client:
             event (Event): The event to record.
         """
 
-        if not self._session is None:
+        if not self._session is None and not self._session.has_ended:
             self._worker.add_event(
                 {'session_id': self._session.session_id, **event.__dict__})
         else:
@@ -161,26 +181,6 @@ class Client:
                 return sync_wrapper
 
         return decorator
-
-    def add_tags(self, tags: List[str]):
-        if self._session is None:
-            return print("You must create a session before assigning tags")
-
-        if self._tags is not None:
-            self._tags.extend(tags)
-        else:
-            self._tags = tags
-
-        self._session.tags = self._tags
-        self._worker.update_session(self._session)
-
-    def set_tags(self, tags: List[str]):
-        if self._session is None:
-            return print("You must create a session before assigning tags")
-
-        self._tags = tags
-        self._session.tags = tags
-        self._worker.update_session(self._session)
 
     def _record_event_sync(self, func, event_name, tags, *args, **kwargs):
         init_time = get_ISO_time()
@@ -299,7 +299,7 @@ class Client:
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
         """
-        if self._session is None:
+        if self._session is None or self._session.has_ended:
             return print("Session has already been ended.")
 
         self._session.video = video

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -47,7 +47,9 @@ class Client:
                  endpoint: Optional[str] = 'https://agentops-server-v2.fly.dev',
                  max_wait_time: Optional[int] = 1000,
                  max_queue_size: Optional[int] = 100,
-                 override=True):
+                 override=True,
+                 bypass_new_session=False
+                 ):
 
         # Get API key from env
         if api_key is None:
@@ -74,7 +76,8 @@ class Client:
         # Override sys.excepthook
         sys.excepthook = self.handle_exception
 
-        self._start_session(tags)
+        if not bypass_new_session:
+            self._start_session(tags)
 
         if override:
             if 'openai' in sys.modules:

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -158,6 +158,21 @@ class Client:
 
         return decorator
 
+    def add_tags(self, tags: List[str]):
+        if self.session.tags is not None:
+            self.session.tags.extend(tags)
+        else:
+            self.session.tags = tags
+
+        self.worker.update_session(self.session)
+
+    def set_tags(self, tags: List[str]):
+        if self.session is None:
+            raise Exception("You must create a session before assigning tags")
+
+        self.session.tags = tags
+        self.worker.update_session(self.session)
+
     def _record_event_sync(self, func, event_name, tags, *args, **kwargs):
         init_time = get_ISO_time()
         func_args = inspect.signature(func).parameters

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -77,7 +77,10 @@ class Client:
         sys.excepthook = self.handle_exception
 
         if not bypass_new_session:
-            self._start_session(tags)
+            self.start_session(tags)
+        else:
+            self.session = None
+            self.worker = None
 
         if override:
             if 'openai' in sys.modules:
@@ -159,6 +162,9 @@ class Client:
         return decorator
 
     def add_tags(self, tags: List[str]):
+        if self.session is None:
+            return print("You must create a session before assigning tags")
+
         if self.session.tags is not None:
             self.session.tags.extend(tags)
         else:
@@ -168,7 +174,7 @@ class Client:
 
     def set_tags(self, tags: List[str]):
         if self.session is None:
-            raise Exception("You must create a session before assigning tags")
+            return print("You must create a session before assigning tags")
 
         self.session.tags = tags
         self.worker.update_session(self.session)
@@ -260,7 +266,7 @@ class Client:
 
         return returns
 
-    def _start_session(self, tags: Optional[List[str]] = None):
+    def start_session(self, tags: Optional[List[str]] = None):
         """
         Start a new session for recording events.
 

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -280,9 +280,7 @@ class Client:
         if self._session is not None:
             return print("Session already started. End this session before starting a new one.")
 
-        self._session = Session(str(uuid4()), tags)
-        if self._tags:
-            self.set_tags(self._tags)
+        self._session = Session(str(uuid4()), tags or self._tags)
         self._worker = Worker(self.config)
         self._worker.start_session(self._session)
 
@@ -301,11 +299,13 @@ class Client:
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
         """
+        if self._session is None:
+            return print("Session has already been ended.")
         if not self._session.has_ended:
             self._session.video = video
             self._session.end_session(end_state, rating, end_state_reason)
             self._worker.end_session(self._session)
-            self._session = None
+            # self._session = None
         else:
             logging.info("Warning: The session has already been ended.")
 

--- a/agentops/langchain_callback_handler.py
+++ b/agentops/langchain_callback_handler.py
@@ -305,7 +305,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
 
     @property
     def session_id(self):
-        return self.ao_client.session.session_id
+        return self.ao_client._session.session_id
 
 
 class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
@@ -596,4 +596,4 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
 
     @property
     def session_id(self):
-        return self.ao_client.session.session_id
+        return self.ao_client._session.session_id

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -1,11 +1,5 @@
 from .helpers import get_ISO_time
-from pydantic import BaseModel, Field
 from typing import Optional, List
-
-
-class SessionState(BaseModel):
-    end_state: str = Field(..., pattern="^(Success|Fail|Indeterminate)$")
-    end_state_reason: Optional[str] = None
 
 
 class Session:
@@ -26,6 +20,9 @@ class Session:
     """
 
     def __init__(self, session_id: str, tags: Optional[List[str]] = None):
+        self.end_timestamp = None
+        self.rating = None
+        self.end_state = None
         self.session_id = session_id
         self.init_timestamp = get_ISO_time()
         self.tags = tags
@@ -50,7 +47,6 @@ class Session:
             rating (str, optional): The rating for the session.
             end_state_reason (str, optional): The reason for ending the session. Provides context for why the session ended.
         """
-        SessionState(end_state=end_state, end_state_reason=end_state_reason)
         self.end_state = end_state
         self.rating = rating
         self.end_state_reason = end_state_reason

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -60,4 +60,4 @@ class Session:
         Returns:
             bool: Whether the session has been ended
         """
-        return hasattr(self, "end_state")
+        return self.end_state is not None

--- a/agentops/worker.py
+++ b/agentops/worker.py
@@ -99,6 +99,18 @@ class Worker:
                             self.config.api_key,
                             self.config.org_key)
 
+    def update_session(self, session: Session) -> None:
+        with self.lock:
+            payload = {
+                "session": session.__dict__
+            }
+
+            HttpClient.post(f'{self.config.endpoint}/sessions',
+                            json.dumps(filter_unjsonable(
+                                payload)).encode("utf-8"),
+                            self.config.api_key,
+                            self.config.org_key)
+
     def run(self) -> None:
         while not self.stop_flag.is_set():
             time.sleep(self.config.max_wait_time / 1000)


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
- Allows a developer to bypass creating a new session on client init. This better supports client wrappers like the Multion implementation.
- Add or reset tags on current session
- Support ending and creating new sessions
