### PR TITLE
feature: display warning messages to users

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -73,24 +73,21 @@ class Client:
                 self.llm_tracker.override_api('openai')
 
     def add_tags(self, tags: List[str]):
-        if self._session is None:
-            return print("You must create a session before assigning tags")
-
         if self._tags is not None:
             self._tags.extend(tags)
         else:
             self._tags = tags
 
-        self._session.tags = self._tags
-        self._worker.update_session(self._session)
+        if self._session is not None:
+            self._session.tags = self._tags
+            self._worker.update_session(self._session)
 
     def set_tags(self, tags: List[str]):
-        if self._session is None:
-            return print("You must create a session before assigning tags")
-
         self._tags = tags
-        self._session.tags = tags
-        self._worker.update_session(self._session)
+
+        if self._session is not None:
+            self._session.tags = tags
+            self._worker.update_session(self._session)
 
     def record(self, event: Event):
         """

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -30,10 +30,13 @@ class Client:
     Client for AgentOps service.
 
     Args:
-        api_key (str, optional): API Key for AgentOps services. If none is provided, key will be read from the AGENTOPS_API_KEY environment variable.
-        tags (List[str], optional): Tags for the sessions that can be used for grouping or sorting later (e.g. ["GPT-4"]).
-        endpoint (str, optional): The endpoint for the AgentOps service. Defaults to 'https://agentops-server-v2.fly.dev'.
-        max_wait_time (int, optional): The maximum time to wait in milliseconds before flushing the queue. Defaults to 1000.
+        api_key (str, optional): API Key for AgentOps services. If none is provided, key will 
+            be read from the AGENTOPS_API_KEY environment variable.
+        tags (List[str], optional): Tags for the sessions that can be used for grouping or 
+            sorting later (e.g. ["GPT-4"]).
+        endpoint (str, optional): The endpoint for the AgentOps service. Defaults to 'https://api.agentops.ai'.
+        max_wait_time (int, optional): The maximum time to wait in milliseconds before flushing the queue. 
+            Defaults to 1000.
         max_queue_size (int, optional): The maximum size of the event queue. Defaults to 100.
         override (bool): Whether to override and LLM calls to emit as events.
     Attributes:
@@ -274,7 +277,8 @@ class Client:
                 frame: The current stack frame.
             """
             signal_name = 'SIGINT' if signum == signal.SIGINT else 'SIGTERM'
-            logging.info(f'Signal {signal_name} detected. Ending session...')
+            logging.info(
+                f'AgentOps: {signal_name} detected. Ending session...')
             self.end_session(end_state='Fail',
                              end_state_reason=f'Signal {signal_name} detected')
             sys.exit(0)
@@ -286,7 +290,8 @@ class Client:
             Args:
                 exc_type (Type[BaseException]): The type of the exception.
                 exc_value (BaseException): The exception instance.
-                exc_traceback (TracebackType): A traceback object encapsulating the call stack at the point where the exception originally occurred.
+                exc_traceback (TracebackType): A traceback object encapsulating the call stack at the 
+                                               point where the exception originally occurred.
             """
             formatted_traceback = ''.join(traceback.format_exception(exc_type, exc_value,
                                                                      exc_traceback))


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Currently, when something goes wrong, nothing is displayed to the user. It just quietly fails in the background. 

We are now surfacing those issues to the user in logging.warn() messages. AgentOps will not interrupt any running agents, but users will be able to see when no API Key is provided, if their API key is valid, and any error messages passed back from the API server

**🧪 Testing**
Manual testing 
-env without api key
-env with wrong api key
-server pointed to wrong database

Closes ENG-71
