### PR TITLE
use environment variable for endpoint

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -47,7 +47,7 @@ class Client(metaclass=ExceptionHandlerMeta):
 
     def __init__(self, api_key: Optional[str] = None,
                  tags: Optional[List[str]] = None,
-                 endpoint: Optional[str] = 'https://api.agentops.ai',
+                 endpoint: Optional[str] = environ.get('AGENTOPS_API_ENDPOINT', 'https://api.agentops.ai'),
                  max_wait_time: Optional[int] = 1000,
                  max_queue_size: Optional[int] = 100,
                  override=True,


### PR DESCRIPTION
If the `AGENTOPS_API_ENDPOINT` environment variable exists, it uses that. Otherwise it falls to the default