### PR TITLE
Refactor of llm_tracker and chatml validation

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -3,5 +3,5 @@
 from .client import Client
 from .event import ActionEvent, LLMEvent, ToolEvent, ErrorEvent
 from .logger import AgentOpsLogger
-from .enums import Models
+from .enums import Models, PromptMessageFormat
 from .decorators import record_function

--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -3,5 +3,5 @@
 from .client import Client
 from .event import ActionEvent, LLMEvent, ToolEvent, ErrorEvent
 from .logger import AgentOpsLogger
-from .enums import Models, PromptMessageFormat
+from .enums import Models, LLMMessageFormat
 from .decorators import record_function

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -142,7 +142,7 @@ class Client(metaclass=MetaClient):
 
         except Exception as e:
             # TODO: add the stack trace
-            self.record(ErrorEvent(event=event, details={f"{type(e).__name__}": str(e)}))
+            self.record(ErrorEvent(trigger_event=event, details={f"{type(e).__name__}": str(e)}))
 
             # Re-raise the exception
             raise
@@ -182,7 +182,7 @@ class Client(metaclass=MetaClient):
 
         except Exception as e:
             # TODO: add the stack trace
-            self.record(ErrorEvent(event=event, details={f"{type(e).__name__}": str(e)}))
+            self.record(ErrorEvent(trigger_event=event, details={f"{type(e).__name__}": str(e)}))
 
             # Re-raise the exception
             raise

--- a/agentops/enums.py
+++ b/agentops/enums.py
@@ -27,3 +27,8 @@ class Models(Enum):
     GPT_4_32K_0314 = "gpt-4-32k-0314"
     GPT_4_0613 = "gpt-4-0613"
     TEXT_EMBEDDING_ADA_002 = "text-embedding-ada-002"
+
+
+class PromptMessageFormat(Enum):
+    STRING = "string"
+    CHATML = "chatml"

--- a/agentops/enums.py
+++ b/agentops/enums.py
@@ -29,6 +29,6 @@ class Models(Enum):
     TEXT_EMBEDDING_ADA_002 = "text-embedding-ada-002"
 
 
-class PromptMessageFormat(Enum):
+class LLMMessageFormat(Enum):
     STRING = "string"
     CHATML = "chatml"

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -56,24 +56,23 @@ class LLMEvent(Event):
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
 
+    def format_messages(self):
+        if self.prompt_messages:
+            # TODO should we just figure out if it's chatml so user doesn't have to pass anything?
+            if self.prompt_messages_format == LLMMessageFormat.STRING:
+                self._formatted_prompt_messages = {"type": "string", "string": self.prompt_messages}
+            elif self.prompt_messages_format == LLMMessageFormat.CHATML:
+                self._formatted_prompt_messages = {"type": "chatml", "messages": self.prompt_messages}
+
+        if self.completion_message:
+            if self.completion_message_format == LLMMessageFormat.STRING:
+                self._formatted_completion_message = {"type": "string", "string": self.completion_message}
+            elif self.completion_message_format == LLMMessageFormat.CHATML:
+                self._formatted_completion_message = {"type": "chatml", "message": self.completion_message}
+
     def __post_init__(self):
-        # TODO should we just figure out if it's chatml so user doesn't have to pass anything?
-        if self.prompt_messages_format == LLMMessageFormat.STRING:
-            self._formatted_prompt_messages = {"type": "string", "string": self.prompt_messages}
-        elif self.prompt_messages_format == LLMMessageFormat.CHATML:
-            self._formatted_prompt_messages = {"type": "chatml", "messages": self.prompt_messages}
-
-        if self.completion_message_format == LLMMessageFormat.STRING:
-            self._formatted_completion_message = {"type": "string", "string": self.completion_message}
-        elif self.completion_message_format == LLMMessageFormat.CHATML:
-            self._formatted_completion_message = {"type": "chatml", "message": self.completion_message}
-
-        # import pprint
-        # import json
-        # print("\n\_formatted_prompt_messages:\n")
-        # pprint(self._formatted_prompt_messages)
-        # print("\n\_formatted_completion_message:\n")
-        # json.dump(self._formatted_completion_message)
+        # format if prompt/completion messages were passed when LLMEvent was created
+        self.format_messages()
 
 
 @dataclass
@@ -92,11 +91,10 @@ class ErrorEvent():
     code: Optional[str] = None
     details: Optional[str] = None
     logs: Optional[str] = None
-    # event_type: str = EventType.ERROR.value # TODO: don't expose this
-    event_type: str = field(init=False, default=EventType.ERROR.value)
     timestamp: str = field(default_factory=get_ISO_time)
 
     def __post_init__(self):
+        self.event_type = EventType.ERROR.value
         if self.trigger_event:
             self.trigger_event_id = self.trigger_event.id
             self.trigger_event_type = self.trigger_event.event_type

--- a/agentops/llm_tracker.py
+++ b/agentops/llm_tracker.py
@@ -49,22 +49,17 @@ class LlmTracker:
                     self.completion += token
 
                 if finish_reason:
-                    # TODO: handle case where finish_reason never gets a value? Do we record an LLMEvent in that case?
                     self.llm_event.agent_id = check_call_stack_for_agent_id()
                     self.llm_event.prompt_messages = kwargs["messages"]
                     self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
                     self.llm_event.completion_message = {"role": "assistant", "content": self.completion}
                     self.llm_event.completion_message_format = LLMMessageFormat.CHATML
-                    # TODO: cannot return response.model_dump() bc response is async generator
                     self.llm_event.returns = {"finish_reason": finish_reason, "content": self.completion}
                     self.llm_event.model = model
                     self.llm_event.end_timestamp = get_ISO_time()
                     self.llm_event.format_messages()
 
                     self.client.record(self.llm_event)
-
-                    # self.llm_event = None
-                    # self.completion = ""
             except Exception as e:
                 self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
                 # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
@@ -97,7 +92,6 @@ class LlmTracker:
             self.llm_event.agent_id = check_call_stack_for_agent_id()
             self.llm_event.prompt_messages = kwargs["messages"]
             self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
-            # TODO: need to coerce this into chatml
             self.llm_event.completion_message = response['choices'][0]['message']
             self.llm_event.completion_message_format = LLMMessageFormat.CHATML
             self.llm_event.returns = {"content": response['choices'][0]['message']['content']}
@@ -106,8 +100,6 @@ class LlmTracker:
             self.llm_event.format_messages()
 
             self.client.record(self.llm_event)
-
-            # self.llm_event = None
         except Exception as e:
             self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
             # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
@@ -144,7 +136,6 @@ class LlmTracker:
                     self.completion += token
 
                 if finish_reason:
-                    # TODO: handle case where finish_reason never gets a value? Do we record an LLMEvent in that case?
                     self.llm_event.agent_id = check_call_stack_for_agent_id()
                     self.llm_event.prompt_messages = kwargs["messages"]
                     self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
@@ -157,9 +148,6 @@ class LlmTracker:
                     self.llm_event.format_messages()
 
                     self.client.record(self.llm_event)
-
-                    # self.llm_event = None
-                    # self.completion = ""
             except Exception as e:
                 self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
                 # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
@@ -206,9 +194,6 @@ class LlmTracker:
             self.llm_event.format_messages()
 
             self.client.record(self.llm_event)
-
-            # self.llm_event = None
-            # Standard response
         except Exception as e:
             self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
             # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths

--- a/tests/openai_handlers/test_llm_tracker_ge_1_async.py
+++ b/tests/openai_handlers/test_llm_tracker_ge_1_async.py
@@ -28,7 +28,7 @@ async def call_openai_async():
     )
 
     print(response)
-    raise ValueError("This is an intentional error for testing.")
+    # raise ValueError("This is an intentional error for testing.")
 
 
 async def main():

--- a/tests/openai_handlers/test_llm_tracker_ge_1_sync.py
+++ b/tests/openai_handlers/test_llm_tracker_ge_1_sync.py
@@ -39,7 +39,7 @@ def call_openai():
     )
 
     print(response)
-    raise ValueError("This is an intentional error for testing.")
+    # raise ValueError("This is an intentional error for testing.")
 
 
 call_openai()

--- a/tests/openai_handlers/test_llm_tracker_ge_1_sync.py
+++ b/tests/openai_handlers/test_llm_tracker_ge_1_sync.py
@@ -26,11 +26,11 @@ def call_openai():
         messages=[
             {
                 "role": "system",
-                "content": "You will be provided with a piece of code, and your task is to explain it in a concise way."
+                "content": "You are an expert haiku writer"
             },
             {
                 "role": "user",
-                "content": "class Log:\n        def __init__(self, path):\n            dirname = os.path.dirname(path)\n            os.makedirs(dirname, exist_ok=True)\n            f = open(path, \"a+\")\n    \n            # Check that the file is newline-terminated\n            size = os.path.getsize(path)\n            if size > 0:\n                f.seek(size - 1)\n                end = f.read(1)\n                if end != \"\\n\":\n                    f.write(\"\\n\")\n            self.f = f\n            self.path = path\n    \n        def log(self, event):\n            event[\"_event_id\"] = str(uuid.uuid4())\n            json.dump(event, self.f)\n            self.f.write(\"\\n\")\n    \n        def state(self):\n            state = {\"complete\": set(), \"last\": None}\n            for line in open(self.path):\n                event = json.loads(line)\n                if event[\"type\"] == \"submit\" and event[\"success\"]:\n                    state[\"complete\"].add(event[\"id\"])\n                    state[\"last\"] = event\n            return state"
+                "content": "write me a haiku about devops"
             }
         ],
         temperature=0.7,

--- a/tests/openai_handlers/test_llm_tracker_lt_1_sync.py
+++ b/tests/openai_handlers/test_llm_tracker_lt_1_sync.py
@@ -27,7 +27,7 @@ def call_openai():
         model='gpt-3.5-turbo', messages=message, temperature=0.5)
 
     print(response)
-    raise ValueError("This is an intentional error for testing.")
+    # raise ValueError("This is an intentional error for testing.")
 
 
 call_openai()


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Refactored llm_tracker to return more data and throw ErrorEvents tied to their LLMEvent. Formatted prompt/completion messages to chatml

**🔄 Related Issue (if applicable)**
ENG-96

**🎯 Goal**
chatml schema validation and useful error recording

**🔍 Additional Context**
We will further parse objects in api server before frontend

**🧪 Testing**
Ran
tests/openai_handlers/_test_handler_openai_v0.py
tests/openai_handlers/_test_handler_openai_v1.py

which test all routes including async/sync and streaming

Thank you for your contribution to Agentops!
