### PR TITLE
Remove Session Ratings

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -213,7 +213,6 @@ class Client(metaclass=MetaClient):
     def end_session(self, end_state: str = Field("Indeterminate",
                                                  description="End state of the session",
                                                  pattern="^(Success|Fail|Indeterminate)$"),
-                    rating: Optional[str] = None,
                     end_state_reason: Optional[str] = None,
                     video: Optional[str] = None):
         """
@@ -221,7 +220,6 @@ class Client(metaclass=MetaClient):
 
         Args:
             end_state (str, optional): The final state of the session.
-            rating (str, optional): The rating for the session.
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
         """

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -227,7 +227,7 @@ class Client(metaclass=MetaClient):
             return logging.warn("AgentOps: Cannot end session - no current session")
 
         self._session.video = video
-        self._session.end_session(end_state, rating, end_state_reason)
+        self._session.end_session(end_state, end_state_reason)
         self._worker.end_session(self._session)
         self._session = None
         self._worker = None

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -15,14 +15,12 @@ class Session:
         init_timestamp (float): The timestamp for when the session started, represented as seconds since the epoch.
         end_timestamp (float, optional): The timestamp for when the session ended, represented as seconds since the epoch. This is only set after end_session is called.
         end_state (str, optional): The final state of the session. Suggested: "Success", "Fail", "Indeterminate"
-        rating (str, optional): The rating for the session.
         end_state_reason (str, optional): The reason for ending the session.
 
     """
 
     def __init__(self, session_id: UUID, tags: Optional[List[str]] = None, host_env: Optional[dict] = None):
         self.end_timestamp = None
-        self.rating = None
         self.end_state = None
         self.session_id = session_id
         self.init_timestamp = get_ISO_time()
@@ -40,7 +38,7 @@ class Session:
         """
         self.video = video
 
-    def end_session(self, end_state: str = "Indeterminate", rating: Optional[str] = None, end_state_reason: Optional[str] = None):
+    def end_session(self, end_state: str = "Indeterminate", end_state_reason: Optional[str] = None):
         """
         End the session with a specified state, rating, and reason.
 
@@ -50,7 +48,6 @@ class Session:
             end_state_reason (str, optional): The reason for ending the session. Provides context for why the session ended.
         """
         self.end_state = end_state
-        self.rating = rating
         self.end_state_reason = end_state_reason
         self.end_timestamp = get_ISO_time()
 


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Ratings were removed from V0.1 of AgentOps, but the SDK client still has the code for it. This PR remove the code
