### PR TITLE
fix: remove unused imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ classifiers = [
 dependencies = [
     "requests==2.31.0",
     "pydantic>=1.9.0",
-    "packaging>=23.1,<24.0",
-    "toml>=0.10.2",
     "psutil==5.9.8"
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Remove the unused imports added for reporting AgentOps version. We are using an internal library now.