### PR TITLE
Refactored end_state

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -6,9 +6,8 @@ from .client import Client
 from .config import Configuration
 from .event import ActionEvent, LLMEvent, ToolEvent, ErrorEvent, Event
 from .event import Event, ActionEvent, LLMEvent, ToolEvent, ErrorEvent
-from .enums import Models, LLMMessageFormat
+from .enums import Models, LLMMessageFormat, EndState
 from .decorators import record_function
-from pydantic import Field
 from os import environ
 
 
@@ -24,9 +23,7 @@ def init(api_key: Optional[str] = None,
     Client(api_key, parent_key, tags, endpoint, max_wait_time, max_queue_size, override, auto_start_session)
 
 
-def end_session(end_state: str = Field("Indeterminate",
-                                       description="End state of the session",
-                                       pattern="^(Success|Fail|Indeterminate)$"),
+def end_session(end_state: str,
                 end_state_reason: Optional[str] = None,
                 video: Optional[str] = None):
     Client().end_session(end_state, end_state_reason, video)

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -230,7 +230,7 @@ class Client(metaclass=MetaClient):
         End the current session with the AgentOps service.
 
         Args:
-            end_state (str): The final state of the session.
+            end_state (str): The final state of the session. Options: Success, Fail, or Indeterminate.
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
         """
@@ -290,7 +290,8 @@ class Client(metaclass=MetaClient):
             # Then call the default excepthook to exit the program
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
-        atexit.register(lambda: cleanup(end_state="Indeterminate", end_state_reason="Process exited normally"))
+        atexit.register(lambda: cleanup(end_state="Indeterminate",
+                        end_state_reason="Process exited without calling end_session()"))
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
         sys.excepthook = handle_exception

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -6,13 +6,13 @@ Classes:
 """
 
 from .event import ActionEvent, ErrorEvent, Event
+from .enums import EndState
 from .helpers import get_ISO_time, singleton, check_call_stack_for_agent_id
 from .session import Session
 from .worker import Worker
 from .host_env import get_host_env
 from uuid import uuid4
 from typing import Optional, List
-from pydantic import Field
 from os import environ
 import traceback
 import logging
@@ -66,7 +66,7 @@ class Client(metaclass=MetaClient):
             api_key = environ.get("AGENTOPS_API_KEY")
             if not api_key:
                 logging.warning("AgentOps: No API key provided - no data will be recorded.")
-            return
+                return
 
         if not parent_key:
             parent_key = environ.get('AGENTOPS_PARENT_KEY', None)
@@ -222,21 +222,23 @@ class Client(metaclass=MetaClient):
         logging.info('View info on this session at https://agentops.ai/dashboard?session_id={}'
                      .format(self._session.session_id))
 
-    def end_session(self, end_state: str = Field("Indeterminate",
-                                                 description="End state of the session",
-                                                 pattern="^(Success|Fail|Indeterminate)$"),
+    def end_session(self,
+                    end_state: str,
                     end_state_reason: Optional[str] = None,
                     video: Optional[str] = None):
         """
         End the current session with the AgentOps service.
 
         Args:
-            end_state (str, optional): The final state of the session.
+            end_state (str): The final state of the session.
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
         """
         if self._session is None or self._session.has_ended:
             return logging.warning("AgentOps: Cannot end session - no current session")
+
+        if not any(end_state == state.value for state in EndState):
+            return logging.warning("AgentOps: Invalid end_state. Please use one of the EndState enums")
 
         self._session.video = video
         self._session.end_session(end_state, end_state_reason)
@@ -288,7 +290,7 @@ class Client(metaclass=MetaClient):
             # Then call the default excepthook to exit the program
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
-        atexit.register(lambda: cleanup(end_state="Success", end_state_reason="Process exited normally"))
+        atexit.register(lambda: cleanup(end_state="Indeterminate", end_state_reason="Process exited normally"))
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
         sys.excepthook = handle_exception

--- a/agentops/enums.py
+++ b/agentops/enums.py
@@ -26,3 +26,9 @@ class Models(Enum):
 class LLMMessageFormat(Enum):
     STRING = "string"
     CHATML = "chatml"
+
+
+class EndState(Enum):
+    SUCCESS = "Success"
+    FAIL = "Fail"
+    INDETERMINATE = "Indeterminate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 ]
 dependencies = [
     "requests==2.31.0",
-    "pydantic>=1.9.0",
     "psutil==5.9.8"
 ]
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     pytest-mock
     requests_mock
     coverage
-    pydantic
     mypy: mypy
     types-requests
     psutil


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
end_state being passed as Pydantic Field and then filtered out in serialization. So never gets a default value. 

**🎯 Goal**
Fix end_state in end_session

**🔍 Additional Context**
Makes sense just to remove Pydantic altogether as this is the last place we use it.