### PR TITLE
feature: Increase max wait time

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -16,8 +16,8 @@ def init(api_key: Optional[str] = None,
          parent_key: Optional[str] = None,
          tags: Optional[List[str]] = None,
          endpoint: Optional[str] = None,
-         max_wait_time: Optional[int] = 1000,
-         max_queue_size: Optional[int] = 100,
+         max_wait_time: Optional[int] = None,
+         max_queue_size: Optional[int] = None,
          override=True,
          auto_start_session=True):
 

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -49,8 +49,8 @@ class Client(metaclass=MetaClient):
                  parent_key: Optional[str] = None,
                  tags: Optional[List[str]] = None,
                  endpoint: Optional[str] = None,
-                 max_wait_time: Optional[int] = 1000,
-                 max_queue_size: Optional[int] = 100,
+                 max_wait_time: Optional[int] = None,
+                 max_queue_size: Optional[int] = None,
                  override=True,
                  auto_start_session=True
                  ):

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -23,7 +23,8 @@ class Configuration:
     def __init__(self, api_key: str,
                  parent_key: Optional[str],
                  endpoint: Optional[str] = environ.get('AGENTOPS_API_ENDPOINT', 'https://api.agentops.ai'),
-                 max_wait_time: Optional[int] = None, max_queue_size: Optional[int] = None):
+                 max_wait_time: Optional[int] = None,
+                 max_queue_size: Optional[int] = None):
         self._api_key: str = api_key
         self._endpoint = endpoint
         self._max_wait_time = max_wait_time or 30000

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -16,18 +16,18 @@ class Configuration:
     Args:
         api_key (str): API Key for AgentOps services
         endpoint (str, optional): The endpoint for the AgentOps service. Defaults to 'https://api.agentops.ai'.
-        max_wait_time (int, optional): The maximum time to wait in milliseconds before flushing the queue. Defaults to 1000.
+        max_wait_time (int, optional): The maximum time to wait in milliseconds before flushing the queue. Defaults to 30000.
         max_queue_size (int, optional): The maximum size of the event queue. Defaults to 100.
     """
 
     def __init__(self, api_key: str,
                  parent_key: Optional[str],
                  endpoint: Optional[str] = environ.get('AGENTOPS_API_ENDPOINT', 'https://api.agentops.ai'),
-                 max_wait_time: Optional[int] = 1000, max_queue_size: Optional[int] = 100):
+                 max_wait_time: Optional[int] = None, max_queue_size: Optional[int] = None):
         self._api_key: str = api_key
         self._endpoint = endpoint
-        self._max_wait_time = max_wait_time
-        self._max_queue_size = max_queue_size
+        self._max_wait_time = max_wait_time or 30000
+        self._max_queue_size = max_queue_size or 100
         self._parent_key: Optional[str] = parent_key
 
     @property

--- a/agentops/worker.py
+++ b/agentops/worker.py
@@ -56,7 +56,7 @@ class Worker:
 
     def end_session(self, session: Session) -> None:
         self.stop_flag.set()
-        self.thread.join()
+        self.thread.join(timeout=1)
         self.flush_queue()
         self._session = None
 


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
We currently default to a 1 second max_wait_time before flushing the queue. This is needlessly often, so this change increases it to 30 seconds. 