### PR TITLE
rename prompt and completions

### DIFF
--- a/agentops/event.py
+++ b/agentops/event.py
@@ -43,31 +43,31 @@ class LLMEvent(Event):
     event_type: str = EventType.LLM.value
     agent_id: Optional[UUID] = None
     thread_id: Optional[UUID] = None
-    prompt_messages: str | List = None  # TODO: remove from serialization
-    prompt_messages_format: LLMMessageFormat = LLMMessageFormat.STRING  # TODO: remove from serialization
+    prompt: str | List = None  # TODO: remove from serialization
+    prompt_format: LLMMessageFormat = LLMMessageFormat.STRING  # TODO: remove from serialization
     # TODO: remove and just create it in __post_init__ so it can never be set by user?
-    _formatted_prompt_messages: object = field(init=False, default=None)
-    completion_message: str | object = None  # TODO: remove from serialization
-    completion_message_format: LLMMessageFormat = LLMMessageFormat.STRING  # TODO: remove from serialization
+    _formatted_prompt: object = field(init=False, default=None)
+    completion: str | object = None  # TODO: remove from serialization
+    completion_format: LLMMessageFormat = LLMMessageFormat.STRING  # TODO: remove from serialization
     # TODO: remove and just create it in __post_init__ so it can never be set by user?
-    _formatted_completion_message: object = field(init=False, default=None)
+    _formatted_completion: object = field(init=False, default=None)
     model: Optional[Models | str] = None
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
 
     def format_messages(self):
-        if self.prompt_messages:
+        if self.prompt:
             # TODO should we just figure out if it's chatml so user doesn't have to pass anything?
-            if self.prompt_messages_format == LLMMessageFormat.STRING:
-                self._formatted_prompt_messages = {"type": "string", "string": self.prompt_messages}
-            elif self.prompt_messages_format == LLMMessageFormat.CHATML:
-                self._formatted_prompt_messages = {"type": "chatml", "messages": self.prompt_messages}
+            if self.prompt_format == LLMMessageFormat.STRING:
+                self._formatted_prompt = {"type": "string", "string": self.prompt}
+            elif self.prompt_format == LLMMessageFormat.CHATML:
+                self._formatted_prompt = {"type": "chatml", "messages": self.prompt}
 
-        if self.completion_message:
-            if self.completion_message_format == LLMMessageFormat.STRING:
-                self._formatted_completion_message = {"type": "string", "string": self.completion_message}
-            elif self.completion_message_format == LLMMessageFormat.CHATML:
-                self._formatted_completion_message = {"type": "chatml", "message": self.completion_message}
+        if self.completion:
+            if self.completion_format == LLMMessageFormat.STRING:
+                self._formatted_completion = {"type": "string", "string": self.completion}
+            elif self.completion_format == LLMMessageFormat.CHATML:
+                self._formatted_completion = {"type": "chatml", "message": self.completion}
 
     def __post_init__(self):
         # format if prompt/completion messages were passed when LLMEvent was created

--- a/agentops/langchain_callback_handler.py
+++ b/agentops/langchain_callback_handler.py
@@ -65,7 +65,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
                     **({} if metadata is None else metadata),
                     **kwargs},  # TODO: params is inconsistent, in ToolEvent we put it in logs
             model=kwargs['invocation_params']['model'],
-            prompt_messages=prompts[0]
+            prompt=prompts[0]
             # tags=tags # TODO
         )
 
@@ -100,8 +100,8 @@ class LangchainCallbackHandler(BaseCallbackHandler):
         }
         llm_event.end_timestamp = get_ISO_time()
         if response.llm_output is not None:
-            llm_event.completion_message = response.generations[0][0].message.content  # TODO
-            llm_event.completion_message_format = LLMMessageFormat.STRING  # TODO
+            llm_event.completion = response.generations[0][0].message.content  # TODO
+            llm_event.completion_format = LLMMessageFormat.STRING  # TODO
             llm_event.prompt_tokens = response.llm_output['token_usage']['prompt_tokens']
             llm_event.completion_tokens = response.llm_output['token_usage']['completion_tokens']
             llm_event.format_messages()  # TODO: Find somewhere logical to call this on the user's behalf. They shouldn't call it
@@ -366,7 +366,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
                     **({} if metadata is None else metadata),
                     **kwargs},  # TODO: params is inconsistent, in ToolEvent we put it in logs
             model=kwargs['invocation_params']['model'],
-            prompt_messages=prompts[0]
+            prompt=prompts[0]
         )
 
     @debug_print_function_params
@@ -427,8 +427,8 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         }
         llm_event.end_timestamp = get_ISO_time()
         if response.llm_output is not None:
-            llm_event.completion_message = response.generations[0][0].message.content  # TODO
-            llm_event.completion_message_format = LLMMessageFormat.STRING  # TODO
+            llm_event.completion = response.generations[0][0].message.content  # TODO
+            llm_event.completion_format = LLMMessageFormat.STRING  # TODO
             llm_event.prompt_tokens = response.llm_output['token_usage']['prompt_tokens']
             llm_event.completion_tokens = response.llm_output['token_usage']['completion_tokens']
             llm_event.format_messages()  # TODO: Find somewhere logical to call this on the user's behalf. They shouldn't call it

--- a/agentops/llm_tracker.py
+++ b/agentops/llm_tracker.py
@@ -50,10 +50,10 @@ class LlmTracker:
 
                 if finish_reason:
                     self.llm_event.agent_id = check_call_stack_for_agent_id()
-                    self.llm_event.prompt_messages = kwargs["messages"]
-                    self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
-                    self.llm_event.completion_message = {"role": "assistant", "content": self.completion}
-                    self.llm_event.completion_message_format = LLMMessageFormat.CHATML
+                    self.llm_event.prompt = kwargs["messages"]
+                    self.llm_event.prompt_format = LLMMessageFormat.CHATML
+                    self.llm_event.completion = {"role": "assistant", "content": self.completion}
+                    self.llm_event.completion_format = LLMMessageFormat.CHATML
                     self.llm_event.returns = {"finish_reason": finish_reason, "content": self.completion}
                     self.llm_event.model = model
                     self.llm_event.end_timestamp = get_ISO_time()
@@ -90,10 +90,10 @@ class LlmTracker:
         # v0.0.0 responses are dicts
         try:
             self.llm_event.agent_id = check_call_stack_for_agent_id()
-            self.llm_event.prompt_messages = kwargs["messages"]
-            self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
-            self.llm_event.completion_message = response['choices'][0]['message']
-            self.llm_event.completion_message_format = LLMMessageFormat.CHATML
+            self.llm_event.prompt = kwargs["messages"]
+            self.llm_event.prompt_format = LLMMessageFormat.CHATML
+            self.llm_event.completion = response['choices'][0]['message']
+            self.llm_event.completion_format = LLMMessageFormat.CHATML
             self.llm_event.returns = {"content": response['choices'][0]['message']['content']}
             self.llm_event.model = response["model"]
             self.llm_event.end_timestamp = get_ISO_time()
@@ -137,10 +137,10 @@ class LlmTracker:
 
                 if finish_reason:
                     self.llm_event.agent_id = check_call_stack_for_agent_id()
-                    self.llm_event.prompt_messages = kwargs["messages"]
-                    self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
-                    self.llm_event.completion_message = {"role": "assistant", "content": self.completion}
-                    self.llm_event.completion_message_format = LLMMessageFormat.CHATML
+                    self.llm_event.prompt = kwargs["messages"]
+                    self.llm_event.prompt_format = LLMMessageFormat.CHATML
+                    self.llm_event.completion = {"role": "assistant", "content": self.completion}
+                    self.llm_event.completion_format = LLMMessageFormat.CHATML
                     self.llm_event.returns = {"finish_reason": finish_reason, "content": self.completion,
                                               "function_call": function_call, "tool_calls": tool_calls, "role": role}
                     self.llm_event.model = model
@@ -185,10 +185,10 @@ class LlmTracker:
         # v1.0.0+ responses are objects
         try:
             self.llm_event.agent_id = check_call_stack_for_agent_id()
-            self.llm_event.prompt_messages = kwargs["messages"]
-            self.llm_event.prompt_messages_format = LLMMessageFormat.CHATML
-            self.llm_event.completion_message = response.choices[0].message.model_dump()
-            self.llm_event.completion_message_format = LLMMessageFormat.CHATML
+            self.llm_event.prompt = kwargs["messages"]
+            self.llm_event.prompt_format = LLMMessageFormat.CHATML
+            self.llm_event.completion = response.choices[0].message.model_dump()
+            self.llm_event.completion_format = LLMMessageFormat.CHATML
             self.llm_event.returns = response.model_dump()
             self.llm_event.model = response.model
             self.llm_event.format_messages()


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
`prompt_messages` is confusing because there is a messages object inside. Same for `completion_message`. To remove the confusion, `prompt_messages` is renamed to `prompt` and same for `completion`
