### PR TITLE
downgrade packaging for langchain support

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -241,7 +241,7 @@ class Client(metaclass=MetaClient):
         self._session.video = video
         self._session.end_session(end_state, end_state_reason)
         token_cost = self._worker.end_session(self._session)
-        if token_cost is 'unknown':
+        if token_cost == 'unknown':
             print('🖇 AgentOps: Could not determine cost of run.')
         else:
             print('🖇 AgentOps: This run cost ${:.6f}'.format(float(token_cost)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "requests==2.31.0",
     "psutil==5.9.8",
-    "packaging==24.0"
+    "packaging==23.2"
 ]
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
We were missing `packaging` in our pyproject.toml. It was added at the current version, but that version is not supported by langchain-core, so we're downgrading to the version that is

also throwing in a warning fix for checking string literal