### PR TITLE
[Feature] Better ErrorEvents

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -150,7 +150,6 @@ class Client(metaclass=MetaClient):
             self.record(event)
 
         except Exception as e:
-            # TODO: add the stack trace
             self.record(ErrorEvent(trigger_event=event, error_type=type(e).__name__, details=str(e)))
 
             # Re-raise the exception
@@ -190,7 +189,6 @@ class Client(metaclass=MetaClient):
             self.record(event)
 
         except Exception as e:
-            # TODO: add the stack trace
             self.record(ErrorEvent(trigger_event=event, error_type=type(e).__name__, details=str(e)))
 
             # Re-raise the exception

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -151,7 +151,7 @@ class Client(metaclass=MetaClient):
 
         except Exception as e:
             # TODO: add the stack trace
-            self.record(ErrorEvent(trigger_event=event, details={f"{type(e).__name__}": str(e)}))
+            self.record(ErrorEvent(trigger_event=event, error_type=type(e).__name__, details=str(e)))
 
             # Re-raise the exception
             raise
@@ -191,7 +191,7 @@ class Client(metaclass=MetaClient):
 
         except Exception as e:
             # TODO: add the stack trace
-            self.record(ErrorEvent(trigger_event=event, details={f"{type(e).__name__}": str(e)}))
+            self.record(ErrorEvent(trigger_event=event, error_type=type(e).__name__, details=str(e)))
 
             # Re-raise the exception
             raise

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -128,7 +128,7 @@ class ErrorEvent():
     error_type: Optional[str] = None
     code: Optional[str] = None
     details: Optional[str] = None
-    logs: Optional[str] = traceback.format_exc()
+    logs: Optional[str] = field(default_factory=traceback.format_exc())
     timestamp: str = field(default_factory=get_ISO_time)
 
     def __post_init__(self):

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -6,9 +6,8 @@ Data Class:
 """
 
 from dataclasses import dataclass, field
-import traceback
 from typing import List, Optional
-from .helpers import get_ISO_time, check_call_stack_for_agent_id
+from .helpers import get_ISO_time, get_traceback, check_call_stack_for_agent_id
 from .enums import EventType, Models
 from uuid import UUID, uuid4
 
@@ -128,7 +127,7 @@ class ErrorEvent():
     error_type: Optional[str] = None
     code: Optional[str] = None
     details: Optional[str] = None
-    logs: Optional[str] = field(default_factory=traceback.format_exc())
+    logs: Optional[str] = field(default_factory=get_traceback)
     timestamp: str = field(default_factory=get_ISO_time)
 
     def __post_init__(self):

--- a/agentops/event.py
+++ b/agentops/event.py
@@ -6,6 +6,7 @@ Data Class:
 """
 
 from dataclasses import dataclass, field
+import traceback
 from typing import List, Optional
 from .helpers import get_ISO_time, check_call_stack_for_agent_id
 from .enums import EventType, Models
@@ -127,7 +128,7 @@ class ErrorEvent():
     error_type: Optional[str] = None
     code: Optional[str] = None
     details: Optional[str] = None
-    logs: Optional[str] = None
+    logs: Optional[str] = traceback.format_exc()
     timestamp: str = field(default_factory=get_ISO_time)
 
     def __post_init__(self):

--- a/agentops/helpers.py
+++ b/agentops/helpers.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 import inspect
 import logging
+import traceback
 from uuid import UUID
 import os
 from importlib.metadata import version
@@ -29,6 +30,10 @@ def get_ISO_time():
         str: The current UTC time as a string in ISO 8601 format.
     """
     return datetime.utcfromtimestamp(time.time()).isoformat(timespec='milliseconds') + 'Z'
+
+def get_traceback():
+    """Returns the current traceback as a string."""
+    return traceback.format_exc()
 
 
 def is_jsonable(x):

--- a/agentops/langchain_callback_handler.py
+++ b/agentops/langchain_callback_handler.py
@@ -80,7 +80,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
         llm_event: LLMEvent = self.events.llm[str(run_id)]
         self.ao_client.record(llm_event)
 
-        error_event = ErrorEvent(trigger_event=llm_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=llm_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -106,7 +106,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
 
         if len(response.generations) == 0:
             # TODO: more descriptive error
-            error_event = ErrorEvent(trigger_event=self.events.llm[str(run_id)],
+            error_event = ErrorEvent(trigger_event=self.events.llm[str(run_id)], error_type="NoGenerations",
                                      details="on_llm_end: No generations", timestamp=get_ISO_time())
             self.ao_client.record(error_event)
 
@@ -156,7 +156,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
         action_event: ActionEvent = self.events.chain[str(run_id)]
         self.ao_client.record(action_event)
 
-        error_event = ErrorEvent(trigger_event=action_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=action_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -199,7 +199,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
         # Tools are capable of failing `on_tool_end` quietly.
         # This is a workaround to make sure we can log it as an error.
         if kwargs.get('name') == '_Exception':
-            error_event = ErrorEvent(trigger_event=tool_event, details=output, timestamp=get_ISO_time())
+            error_event = ErrorEvent(trigger_event=tool_event, error_type="LangchainToolException", details=output, timestamp=get_ISO_time())
             self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -214,7 +214,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
         tool_event: ToolEvent = self.events.tool[str(run_id)]
         self.ao_client.record(tool_event)
 
-        error_event = ErrorEvent(trigger_event=tool_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=tool_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -265,7 +265,7 @@ class LangchainCallbackHandler(BaseCallbackHandler):
         action_event: ActionEvent = self.events.retriever[str(run_id)]
         self.ao_client.record(action_event)
 
-        error_event = ErrorEvent(trigger_event=action_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=action_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -405,7 +405,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         llm_event: LLMEvent = self.events.llm[str(run_id)]
         self.ao_client.record(llm_event)
 
-        error_event = ErrorEvent(trigger_event=llm_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=llm_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -431,7 +431,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
 
         if len(response.generations) == 0:
             # TODO: more descriptive error
-            error_event = ErrorEvent(trigger_event=self.events.llm[str(run_id)],
+            error_event = ErrorEvent(trigger_event=self.events.llm[str(run_id)], error_type="NoGenerations"
                                      details="on_llm_end: No generations", timestamp=get_ISO_time())
             self.ao_client.record(error_event)
 
@@ -481,7 +481,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         action_event: ActionEvent = self.events.chain[str(run_id)]
         self.ao_client.record(action_event)
 
-        error_event = ErrorEvent(trigger_event=action_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=action_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -524,7 +524,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         # Tools are capable of failing `on_tool_end` quietly.
         # This is a workaround to make sure we can log it as an error.
         if kwargs.get('name') == '_Exception':
-            error_event = ErrorEvent(trigger_event=tool_event, details=output, timestamp=get_ISO_time())
+            error_event = ErrorEvent(trigger_event=tool_event, error_type="LangchainToolException" details=output, timestamp=get_ISO_time())
             self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -539,7 +539,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         tool_event: ToolEvent = self.events.tool[str(run_id)]
         self.ao_client.record(tool_event)
 
-        error_event = ErrorEvent(trigger_event=tool_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=tool_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params
@@ -590,7 +590,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         action_event: ActionEvent = self.events.retriever[str(run_id)]
         self.ao_client.record(action_event)
 
-        error_event = ErrorEvent(trigger_event=action_event, details=str(error), timestamp=get_ISO_time())
+        error_event = ErrorEvent(trigger_event=action_event, error_type=type(error).__name__, details=str(error), timestamp=get_ISO_time())
         self.ao_client.record(error_event)
 
     @debug_print_function_params

--- a/agentops/langchain_callback_handler.py
+++ b/agentops/langchain_callback_handler.py
@@ -431,7 +431,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
 
         if len(response.generations) == 0:
             # TODO: more descriptive error
-            error_event = ErrorEvent(trigger_event=self.events.llm[str(run_id)], error_type="NoGenerations"
+            error_event = ErrorEvent(trigger_event=self.events.llm[str(run_id)], error_type="NoGenerations",
                                      details="on_llm_end: No generations", timestamp=get_ISO_time())
             self.ao_client.record(error_event)
 
@@ -524,7 +524,7 @@ class AsyncLangchainCallbackHandler(AsyncCallbackHandler):
         # Tools are capable of failing `on_tool_end` quietly.
         # This is a workaround to make sure we can log it as an error.
         if kwargs.get('name') == '_Exception':
-            error_event = ErrorEvent(trigger_event=tool_event, error_type="LangchainToolException" details=output, timestamp=get_ISO_time())
+            error_event = ErrorEvent(trigger_event=tool_event, error_type="LangchainToolException", details=output, timestamp=get_ISO_time())
             self.ao_client.record(error_event)
 
     @debug_print_function_params

--- a/agentops/llm_tracker.py
+++ b/agentops/llm_tracker.py
@@ -97,7 +97,7 @@ class LlmTracker:
 
             self.client.record(self.llm_event)
         except Exception as e:
-            self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e))
+            self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e)))
             # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
             logging.warning(
                 f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")
@@ -143,7 +143,7 @@ class LlmTracker:
 
                     self.client.record(self.llm_event)
             except Exception as e:
-                self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e))
+                self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e)))
                 # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
                 logging.warning(
                     f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")
@@ -188,7 +188,7 @@ class LlmTracker:
 
             self.client.record(self.llm_event)
         except Exception as e:
-            self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e))
+            self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e)))
             # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
             logging.warning(
                 f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")

--- a/agentops/llm_tracker.py
+++ b/agentops/llm_tracker.py
@@ -58,7 +58,7 @@ class LlmTracker:
 
                     self.client.record(self.llm_event)
             except Exception as e:
-                self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
+                self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e)))
                 # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
                 logging.warning(
                     f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")
@@ -97,7 +97,7 @@ class LlmTracker:
 
             self.client.record(self.llm_event)
         except Exception as e:
-            self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
+            self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e))
             # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
             logging.warning(
                 f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")
@@ -143,7 +143,7 @@ class LlmTracker:
 
                     self.client.record(self.llm_event)
             except Exception as e:
-                self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
+                self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e))
                 # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
                 logging.warning(
                     f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")
@@ -188,7 +188,7 @@ class LlmTracker:
 
             self.client.record(self.llm_event)
         except Exception as e:
-            self.client.record(ErrorEvent(trigger_event=self.llm_event, details={f"{type(e).__name__}": str(e)}))
+            self.client.record(ErrorEvent(trigger_event=self.llm_event, error_type=type(e).__name__, details=str(e))
             # TODO: This error is specific to only one path of failure. Should be more generic or have different logging for different paths
             logging.warning(
                 f"🖇 AgentOps: Unable to parse a chunk for LLM call {kwargs} - skipping upload to AgentOps")


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
We are currently not recording the error types anywhere and instead loading it into the details field. This change makes use of the error types field and automatically captures stack traces.

Need recommendations for names for the Langchain handler!

@HowieG, are all of the fields in ErrorEvent sent to the API server? Is there a way for us to create an exceptions field that auto populates the error_type and details fields (if they aren't provided)?