### PR TITLE
allow host env opt out

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -43,7 +43,6 @@ def init(api_key: Optional[str] = None,
             instrument_llm_calls (bool): Whether to instrument LLM calls and emit LLMEvents..
             auto_start_session (bool): Whether to start a session automatically when the client is created.
             inherited_session_id (optional, str): Init Agentops with an existing Session
-            env_data_opt_out (optional, bool): Opt out of AgentOps tracking environment data for debugging like storage, memory and CPU
         Attributes:
     """
     set_logging_level_info()
@@ -56,8 +55,7 @@ def init(api_key: Optional[str] = None,
                override=override,
                instrument_llm_calls=instrument_llm_calls,
                auto_start_session=auto_start_session,
-               inherited_session_id=inherited_session_id,
-               env_data_opt_out=env_data_opt_out
+               inherited_session_id=inherited_session_id
                )
 
     return inherited_session_id or c.current_session_id

--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -20,7 +20,8 @@ def init(api_key: Optional[str] = None,
          override: Optional[bool] = None,  # Deprecated
          instrument_llm_calls=True,
          auto_start_session=True,
-         inherited_session_id: Optional[str] = None
+         inherited_session_id: Optional[str] = None,
+         env_data_opt_out: Optional[bool] = False
          ):
     """
         Initializes the AgentOps singleton pattern.
@@ -42,6 +43,7 @@ def init(api_key: Optional[str] = None,
             instrument_llm_calls (bool): Whether to instrument LLM calls and emit LLMEvents..
             auto_start_session (bool): Whether to start a session automatically when the client is created.
             inherited_session_id (optional, str): Init Agentops with an existing Session
+            env_data_opt_out (optional, bool): Opt out of AgentOps tracking environment data for debugging like storage, memory and CPU
         Attributes:
     """
     set_logging_level_info()
@@ -54,7 +56,8 @@ def init(api_key: Optional[str] = None,
                override=override,
                instrument_llm_calls=instrument_llm_calls,
                auto_start_session=auto_start_session,
-               inherited_session_id=inherited_session_id
+               inherited_session_id=inherited_session_id,
+               env_data_opt_out=env_data_opt_out
                )
 
     return inherited_session_id or c.current_session_id

--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -20,8 +20,7 @@ def init(api_key: Optional[str] = None,
          override: Optional[bool] = None,  # Deprecated
          instrument_llm_calls=True,
          auto_start_session=True,
-         inherited_session_id: Optional[str] = None,
-         env_data_opt_out: Optional[bool] = False
+         inherited_session_id: Optional[str] = None
          ):
     """
         Initializes the AgentOps singleton pattern.

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -238,7 +238,7 @@ class Client(metaclass=MetaClient):
         if not config and not self.config:
             return logger.warning("🖇 AgentOps: Cannot start session - missing configuration")
 
-        self._session = Session(inherited_session_id or uuid4(), tags or self._tags, host_env=(get_host_env() if self._env_data_opt_out else None))
+        self._session = Session(inherited_session_id or uuid4(), tags or self._tags, host_env=get_host_env(self._env_data_opt_out))
         self._worker = Worker(config or self.config)
         start_session_result = self._worker.start_session(self._session)
         if not start_session_result:

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -4,6 +4,7 @@
     Classes:
         Client: Provides methods to interact with the AgentOps service.
 """
+import os
 
 from .event import ActionEvent, ErrorEvent, Event
 from .enums import EndState
@@ -50,7 +51,6 @@ class Client(metaclass=MetaClient):
             instrument_llm_calls (bool): Whether to instrument LLM calls and emit LLMEvents..
             auto_start_session (bool): Whether to start a session automatically when the client is created.
             inherited_session_id (optional, str): Init Agentops with an existing Session
-            env_data_opt_out (optional, bool): Opt out of AgentOps tracking environment data for debugging like storage, memory and CPU
         Attributes:
             _session (Session, optional): A Session is a grouping of events (e.g. a run of your agent).
             _worker (Worker, optional): A Worker manages the event queue and sends session updates to the AgentOps api server
@@ -66,8 +66,7 @@ class Client(metaclass=MetaClient):
                  override: Optional[bool] = None,  # Deprecated
                  instrument_llm_calls=True,
                  auto_start_session=True,
-                 inherited_session_id: Optional[str] = None,
-                 env_data_opt_out: Optional[bool] = False
+                 inherited_session_id: Optional[str] = None
                  ):
 
         if override is not None:
@@ -79,7 +78,7 @@ class Client(metaclass=MetaClient):
         self._worker = None
         self._tags = tags
 
-        self._env_data_opt_out = env_data_opt_out
+        self._env_data_opt_out = os.getenv('AGENTOPS_ENV_DATA_OPT_OUT') and os.getenv('AGENTOPS_ENV_DATA_OPT_OUT').lower() == 'true'
 
         try:
             self.config = Configuration(api_key=api_key,

--- a/agentops/host_env.py
+++ b/agentops/host_env.py
@@ -54,11 +54,17 @@ def get_disk_details():
     return disk_info
 
 
-def get_host_env():
-    return {
-        "SDK": get_sdk_details(),
-        "OS": get_os_details(),
-        "CPU": get_cpu_details(),
-        "RAM": get_ram_details(),
-        "Disk": get_disk_details(),
-    }
+def get_host_env(opt_out: bool = False):
+    if opt_out:
+        return {
+            "SDK": get_sdk_details(),
+            "OS": get_os_details()
+        }
+    else:
+        return {
+            "SDK": get_sdk_details(),
+            "OS": get_os_details(),
+            "CPU": get_cpu_details(),
+            "RAM": get_ram_details(),
+            "Disk": get_disk_details(),
+        }


### PR DESCRIPTION
Closes #172 

Allows a user to opt out of host environment monitoring with a flag in the `agentops.init()` function