### PR TITLE
set end timestamp if not set before record

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -272,13 +272,13 @@ class Client(metaclass=MetaClient):
 
         self._session.video = video
         self._session.end_session(end_state, end_state_reason)
-        token_cost = Decimal(self._worker.end_session(self._session))
+        token_cost = self._worker.end_session(self._session)
         if token_cost == 'unknown':
             print('🖇 AgentOps: Could not determine cost of run.')
         else:
-
+            token_cost_d = Decimal(token_cost)
             print('🖇 AgentOps: This run cost ${}'.format('{:.2f}'.format(
-                token_cost) if token_cost == 0 else '{:.6f}'.format(token_cost)))
+                token_cost_d) if token_cost_d == 0 else '{:.6f}'.format(token_cost_d)))
         self._session = None
         self._worker = None
 

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -75,6 +75,7 @@ class Client(metaclass=MetaClient):
 
         self._session = None
         self._worker = None
+        self._tags_for_future_session = None
 
         self._env_data_opt_out = os.getenv('AGENTOPS_ENV_DATA_OPT_OUT') and os.getenv('AGENTOPS_ENV_DATA_OPT_OUT').lower() == 'true'
 

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -135,7 +135,8 @@ class Client(metaclass=MetaClient):
             Args:
                 event (Event): The event to record.
         """
-
+        if not event.end_timestamp or event.init_timestamp == event.end_timestamp:
+            event.end_timestamp = get_ISO_time()
         if self._session is not None and not self._session.has_ended:
             if isinstance(event, ErrorEvent):
                 if event.trigger_event:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,31 @@
+import time
+import requests_mock
+import pytest
+import agentops
+from agentops import ActionEvent
+
+
+@pytest.fixture
+def mock_req():
+    with requests_mock.Mocker() as m:
+        url = 'https://api.agentops.ai'
+        m.post(url + '/events', text='ok')
+        m.post(url + '/sessions', json={'status': 'success', 'token_cost': 5})
+        yield m
+
+class TestEvents:
+    def setup_method(self):
+        self.api_key = "random_api_key"
+        self.event_type = 'test_event_type'
+        self.config = agentops.Configuration(api_key=self.api_key, max_wait_time=50, max_queue_size=1)
+
+    def test_record_timestamp(self, mock_req):
+        # agentops.init(api_key=self.api_key, max_wait_time=50, auto_start_session=False)
+        agentops.init(api_key=self.api_key)
+        agentops.start_session(config=self.config)
+
+        event = ActionEvent(self.event_type)
+        time.sleep(0.15)
+        agentops.record(event)
+
+        assert event.init_timestamp != event.end_timestamp

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,11 +20,9 @@ class TestEvents:
         self.config = agentops.Configuration(api_key=self.api_key, max_wait_time=50, max_queue_size=1)
 
     def test_record_timestamp(self, mock_req):
-        # agentops.init(api_key=self.api_key, max_wait_time=50, auto_start_session=False)
         agentops.init(api_key=self.api_key)
-        agentops.start_session(config=self.config)
 
-        event = ActionEvent(self.event_type)
+        event = ActionEvent()
         time.sleep(0.15)
         agentops.record(event)
 


### PR DESCRIPTION
Closes ENG-330

If the developer does not set an end_timestamp, calling `record()` will set it
