### PR TITLE
add stop_instrumenting

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -9,6 +9,7 @@ from .enums import Models
 from .decorators import record_function
 from .agent import track_agent
 from .log_config import set_logging_level_info, set_logging_level_critial
+from .langchain_callback_handler import LangchainCallbackHandler, AsyncLangchainCallbackHandler
 
 
 def init(api_key: Optional[str] = None,
@@ -128,3 +129,6 @@ def set_parent_key(parent_key):
             parent_key (str): The API key of the parent organization to set.
     """
     Client().set_parent_key(parent_key)
+
+def stop_instrumenting():
+    Client().stop_instrumenting()

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -136,7 +136,7 @@ class Client(metaclass=MetaClient):
             Args:
                 event (Event): The event to record.
         """
-        if not event.end_timestamp or event.init_timestamp == event.end_timestamp:
+        if isinstance(event, Event) and not event.end_timestamp or event.init_timestamp == event.end_timestamp:
             event.end_timestamp = get_ISO_time()
         if self._session is not None and not self._session.has_ended:
             if isinstance(event, ErrorEvent):
@@ -356,3 +356,6 @@ class Client(metaclass=MetaClient):
     @property
     def parent_key(self):
         return self.config.parent_key
+
+    def stop_instrumenting(self):
+        self.llm_tracker.stop_instrumenting()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     types-requests
     psutil
     openai
+    langchain-core
+    langchain
 commands =
     coverage run --source agentops -m pytest
     coverage report -m


### PR DESCRIPTION
Allows frameworks to stop_instrumenting LLM providers if the user doesn't pass `auto_instrument=False` into `agentops.init()`

This is useful for frameworks using langchain for LLM calls.