### PR TITLE
Updated logo to point to GitHub raw user content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://agentops.ai?ref=gh">
-    <img src="https://github.com/AgentOps-AI/agentops/blob/df22e9dffb7294fb977dc103a2ca3bcf8f04946f/logo.png" style="margin: 15px; max-width: 300px" width="50%" alt="Logo">
+    <img src="https://raw.githubusercontent.com/AgentOps-AI/agentops/e6002beaf277762fa2b9fa5240a1216b335d7e2c/logo.png" style="margin: 15px; max-width: 300px" width="50%" alt="Logo">
   </a>
 </div>
 <p align="center">


### PR DESCRIPTION
Surprise, surprise-- another update to readme.

This SHOULD fix the Pypi logo being broken 
<img width="806" alt="image" src="https://github.com/AgentOps-AI/agentops/assets/14807319/f2747842-4162-4459-b0ef-a5559e496570">
