### PR TITLE
Fix: not having langchain no longer raises an unhandled exception

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -9,8 +9,10 @@ from .enums import Models
 from .decorators import record_function
 from .agent import track_agent
 from .log_config import set_logging_level_info, set_logging_level_critial
-from .langchain_callback_handler import LangchainCallbackHandler, AsyncLangchainCallbackHandler
-
+try:
+    from .langchain_callback_handler import LangchainCallbackHandler, AsyncLangchainCallbackHandler
+except ModuleNotFoundError:
+    pass
 
 def init(api_key: Optional[str] = None,
          parent_key: Optional[str] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.1.10"
+version = "0.1.11"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Langchain inadvertently became a requirement to run agentops, even though it is not a dependency. That was because when we expose the langchain handler through init, langchain code became required. This change handles the exception so that langchain is no longer required
