### PR TITLE
Tag as list

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -157,6 +157,11 @@ class Client(metaclass=MetaClient):
             tags (List[str]): The list of tags to append.
         """
 
+        # if a string and not a list of strings
+        if not (isinstance(tags, list) and all(isinstance(item, str) for item in tags)):
+            if isinstance(tags, str):  # if it's a single string
+                tags = [tags]  # make it a list
+
         if self._session:
             if self._session.tags is not None:
                 for tag in tags:

--- a/agentops/partners/autogen_logger.py
+++ b/agentops/partners/autogen_logger.py
@@ -31,6 +31,9 @@ F = TypeVar("F", bound=Callable[..., Any])
 class AutogenLogger(BaseLogger):
     agent_store: [{"agentops_id": str, "autogen_id": str}] = []
 
+    def __init__(self):
+        agentops.add_tags(["autogen"])
+
     def start(self) -> str:
         pass
 


### PR DESCRIPTION
- gracefully handle if a developer adds tags as a string instead of list of strings
- autogen-logger automatically adds `autogen` tag