### PR TITLE
support to skip crew ending sessions automatically

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -30,6 +30,7 @@ def init(
     instrument_llm_calls=True,
     auto_start_session=True,
     inherited_session_id: Optional[str] = None,
+    skip_auto_end_session: Optional[bool] = False,
 ):
     """
     Initializes the AgentOps singleton pattern.
@@ -51,6 +52,7 @@ def init(
         instrument_llm_calls (bool): Whether to instrument LLM calls and emit LLMEvents..
         auto_start_session (bool): Whether to start a session automatically when the client is created.
         inherited_session_id (optional, str): Init Agentops with an existing Session
+        skip_auto_end_session (optional, bool): Don't automatically end session based on your framework's decision making
     Attributes:
     """
     logging_level = os.getenv("AGENTOPS_LOGGING_LEVEL")
@@ -74,13 +76,17 @@ def init(
         instrument_llm_calls=instrument_llm_calls,
         auto_start_session=auto_start_session,
         inherited_session_id=inherited_session_id,
+        skip_auto_end_session=skip_auto_end_session,
     )
 
     return inherited_session_id or c.current_session_id
 
 
 def end_session(
-    end_state: str, end_state_reason: Optional[str] = None, video: Optional[str] = None
+    end_state: str,
+    end_state_reason: Optional[str] = None,
+    video: Optional[str] = None,
+    is_auto_end: Optional[bool] = False,
 ):
     """
     End the current session with the AgentOps service.
@@ -89,8 +95,14 @@ def end_session(
         end_state (str): The final state of the session. Options: Success, Fail, or Indeterminate.
         end_state_reason (str, optional): The reason for ending the session.
         video (str, optional): URL to a video recording of the session
+        is_auto_end (bool, optional): is this an automatic use of end_session and should be skipped with bypass_auto_end_session
     """
-    Client().end_session(end_state, end_state_reason, video)
+    Client().end_session(
+        end_state=end_state,
+        end_state_reason=end_state_reason,
+        video=video,
+        is_auto_end=is_auto_end,
+    )
 
 
 def start_session(

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -57,6 +57,7 @@ class Client(metaclass=MetaClient):
         instrument_llm_calls (bool): Whether to instrument LLM calls and emit LLMEvents..
         auto_start_session (bool): Whether to start a session automatically when the client is created.
         inherited_session_id (optional, str): Init Agentops with an existing Session
+        skip_auto_end_session (optional, bool): Don't automatically end session based on your framework's decision making
     Attributes:
         _session (Session, optional): A Session is a grouping of events (e.g. a run of your agent).
         _worker (Worker, optional): A Worker manages the event queue and sends session updates to the AgentOps api
@@ -75,6 +76,7 @@ class Client(metaclass=MetaClient):
         instrument_llm_calls=True,
         auto_start_session=True,
         inherited_session_id: Optional[str] = None,
+        skip_auto_end_session: Optional[bool] = False,
     ):
 
         if override is not None:
@@ -101,6 +103,7 @@ class Client(metaclass=MetaClient):
                 endpoint=endpoint,
                 max_wait_time=max_wait_time,
                 max_queue_size=max_queue_size,
+                skip_auto_end_session=skip_auto_end_session,
             )
 
             if inherited_session_id is not None:
@@ -362,6 +365,7 @@ class Client(metaclass=MetaClient):
         end_state: str,
         end_state_reason: Optional[str] = None,
         video: Optional[str] = None,
+        is_auto_end: Optional[bool] = None,
     ):
         """
         End the current session with the AgentOps service.
@@ -370,7 +374,11 @@ class Client(metaclass=MetaClient):
             end_state (str): The final state of the session. Options: Success, Fail, or Indeterminate.
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
+            is_auto_end (bool, optional): is this an automatic use of end_session and should be skipped with bypass_auto_end_session
         """
+
+        if self.config.skip_auto_end_session:
+            return
 
         if self._session is None or self._session.has_ended:
             return logger.warning("Cannot end session - no current session")

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -374,7 +374,7 @@ class Client(metaclass=MetaClient):
             end_state (str): The final state of the session. Options: Success, Fail, or Indeterminate.
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
-            is_auto_end (bool, optional): is this an automatic use of end_session and should be skipped with bypass_auto_end_session
+            is_auto_end (bool, optional): is this an automatic use of end_session and should be skipped with skip_auto_end_session
         """
 
         if is_auto_end and self.config.skip_auto_end_session:

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -377,7 +377,7 @@ class Client(metaclass=MetaClient):
             is_auto_end (bool, optional): is this an automatic use of end_session and should be skipped with bypass_auto_end_session
         """
 
-        if self.config.skip_auto_end_session:
+        if is_auto_end and self.config.skip_auto_end_session:
             return
 
         if self._session is None or self._session.has_ended:

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -32,6 +32,7 @@ class Configuration:
         endpoint: Optional[str] = None,
         max_wait_time: Optional[int] = None,
         max_queue_size: Optional[int] = None,
+        skip_auto_end_session: Optional[bool] = False,
     ):
 
         if not api_key:
@@ -52,6 +53,7 @@ class Configuration:
         self._max_wait_time = max_wait_time or 5000
         self._max_queue_size = max_queue_size or 100
         self._parent_key: Optional[str] = parent_key
+        self._skip_auto_end_session: Optional[bool] = skip_auto_end_session
 
     @property
     def api_key(self) -> str:
@@ -136,6 +138,10 @@ class Configuration:
     @property
     def parent_key(self):
         return self._parent_key
+
+    @property
+    def skip_auto_end_session(self):
+        return self._skip_auto_end_session
 
     @parent_key.setter
     def parent_key(self, value: str):

--- a/docs/v1/integrations/crewai.mdx
+++ b/docs/v1/integrations/crewai.mdx
@@ -92,6 +92,14 @@ Crew has comprehensive [documentation](https://docs.crewai.com) available as wel
 	</Step>
 </Steps>
 
+## Special Considerations with Crew
+The Crew framework is capable of determining when all tasks have been accomplished and to halt execution. AgentOps will automatically end your active session
+when this determination is made. If you don't want your AgentOps session to end at this time, add an optional parameter to your `agentops.init()` call.
+
+```python
+agentops.init(skip_auto_end_session=True)
+```
+
 ## Crew + AgentOps Examples
 
 <CardGroup cols={3}>

--- a/docs/v1/usage/sdk-reference.mdx
+++ b/docs/v1/usage/sdk-reference.mdx
@@ -25,6 +25,7 @@ The first element of AgentOps is always calling .init()
 - `instrument_llm_calls` (bool): Whether to instrument LLM calls and emit LLMEvents.
 - `auto_start_session` (bool): Whether to start a session automatically when the client is created. You may wish to delay starting a session in order to do additional setup or starting a session on a child process.
 - `inherited_session_id` (str, optional): When creating the client, passing in this value will connect the client to an existing session. This is useful when having separate processes contribute to the same session.
+- `skip_auto_end_session` (bool, optional): If you are using a framework such as Crew, the framework can decide when to halt execution. Setting this parameter to true will not end your agentops session when this happens.
 
 **Returns**:
 


### PR DESCRIPTION
Closes #198 

Crew has the ability to automatically detect when all tasks are complete and to end execution. If the developer doesn't wish for their AgentOps session to end at this time, they can pass an optional parameter into `init()` to skip this.