### PR TITLE
fix: dupe client created with autogen

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -97,6 +97,8 @@ class Client(metaclass=MetaClient):
             os.environ.get("AGENTOPS_ENV_DATA_OPT_OUT", "False").lower() == "true"
         )
 
+        self.config = None
+
         try:
             self.config = Configuration(
                 api_key=api_key,
@@ -142,6 +144,7 @@ class Client(metaclass=MetaClient):
                         from .partners.autogen_logger import AutogenLogger
 
                         autogen.runtime_logging.start(logger=AutogenLogger())
+                        self.add_tags(["autogen"])
                     except ImportError:
                         pass
                     except Exception as e:

--- a/agentops/partners/autogen_logger.py
+++ b/agentops/partners/autogen_logger.py
@@ -32,7 +32,7 @@ class AutogenLogger(BaseLogger):
     agent_store: [{"agentops_id": str, "autogen_id": str}] = []
 
     def __init__(self):
-        agentops.add_tags(["autogen"])
+        pass
 
     def start(self) -> str:
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },


### PR DESCRIPTION
Addresses two issues:

- If `ConfigurationError` is thrown, we dont create a Config property on the client, causing an invalid reference issue later.
- We cannot use `agentops.add_tags()` in the constructor of the client, because it relies on the singleton pattern and the client has not been fully constructed yet.