### PR TITLE
agentops functions dont work without first calling init

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -126,7 +126,6 @@ def end_session(
     )
 
 
-@check_init
 def start_session(
     tags: Optional[List[str]] = None,
     config: Optional[Configuration] = None,
@@ -140,7 +139,16 @@ def start_session(
             e.g. ["test_run"].
         config: (Configuration, optional): Client configuration object
     """
-    return Client().start_session(tags, config, inherited_session_id)
+
+    try:
+        sess_result = Client().start_session(tags, config, inherited_session_id)
+
+        global is_initialized
+        is_initialized = True
+
+        return sess_result
+    except Exception:
+        pass
 
 
 @check_init

--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -143,7 +143,7 @@ def start_session(
     return Client().start_session(tags, config, inherited_session_id)
 
 
-# @check_init
+@check_init
 def record(event: Union[Event, ErrorEvent]):
     """
     Record an event with the AgentOps service.
@@ -154,7 +154,7 @@ def record(event: Union[Event, ErrorEvent]):
     Client().record(event)
 
 
-# @check_init
+@check_init
 def add_tags(tags: List[str]):
     """
     Append to session tags at runtime.
@@ -165,7 +165,7 @@ def add_tags(tags: List[str]):
     Client().add_tags(tags)
 
 
-# @check_init
+@check_init
 def set_tags(tags: List[str]):
     """
     Replace session tags at runtime.
@@ -194,6 +194,6 @@ def stop_instrumenting():
     Client().stop_instrumenting()
 
 
-# @check_init
+@check_init
 def create_agent(name: str, agent_id: Optional[str] = None):
     return Client().create_agent(name=name, agent_id=agent_id)

--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -1,4 +1,5 @@
 # agentops/__init__.py
+import functools
 import os
 import logging
 from typing import Optional, List, Union
@@ -25,11 +26,15 @@ def noop(*args, **kwargs):
     return
 
 
-def check_init(child_function, *args, **kwargs):
-    if is_initialized:
-        return child_function(*args, **kwargs)
-    else:
-        return noop
+def check_init(child_function):
+    @functools.wraps(child_function)
+    def wrapper(*args, **kwargs):
+        if is_initialized:
+            return child_function(*args, **kwargs)
+        else:
+            return noop(*args, **kwargs)
+
+    return wrapper
 
 
 def init(
@@ -138,7 +143,7 @@ def start_session(
     return Client().start_session(tags, config, inherited_session_id)
 
 
-@check_init
+# @check_init
 def record(event: Union[Event, ErrorEvent]):
     """
     Record an event with the AgentOps service.
@@ -149,7 +154,7 @@ def record(event: Union[Event, ErrorEvent]):
     Client().record(event)
 
 
-@check_init
+# @check_init
 def add_tags(tags: List[str]):
     """
     Append to session tags at runtime.
@@ -160,7 +165,7 @@ def add_tags(tags: List[str]):
     Client().add_tags(tags)
 
 
-@check_init
+# @check_init
 def set_tags(tags: List[str]):
     """
     Replace session tags at runtime.
@@ -189,6 +194,6 @@ def stop_instrumenting():
     Client().stop_instrumenting()
 
 
-@check_init
+# @check_init
 def create_agent(name: str, agent_id: Optional[str] = None):
     return Client().create_agent(name=name, agent_id=agent_id)

--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -18,6 +18,19 @@ try:
 except ModuleNotFoundError:
     pass
 
+is_initialized = False
+
+
+def noop(*args, **kwargs):
+    return
+
+
+def check_init(child_function, *args, **kwargs):
+    if is_initialized:
+        return child_function(*args, **kwargs)
+    else:
+        return noop
+
 
 def init(
     api_key: Optional[str] = None,
@@ -79,6 +92,9 @@ def init(
         skip_auto_end_session=skip_auto_end_session,
     )
 
+    global is_initialized
+    is_initialized = True
+
     return inherited_session_id or c.current_session_id
 
 
@@ -105,6 +121,7 @@ def end_session(
     )
 
 
+@check_init
 def start_session(
     tags: Optional[List[str]] = None,
     config: Optional[Configuration] = None,
@@ -121,6 +138,7 @@ def start_session(
     return Client().start_session(tags, config, inherited_session_id)
 
 
+@check_init
 def record(event: Union[Event, ErrorEvent]):
     """
     Record an event with the AgentOps service.
@@ -131,6 +149,7 @@ def record(event: Union[Event, ErrorEvent]):
     Client().record(event)
 
 
+@check_init
 def add_tags(tags: List[str]):
     """
     Append to session tags at runtime.
@@ -141,6 +160,7 @@ def add_tags(tags: List[str]):
     Client().add_tags(tags)
 
 
+@check_init
 def set_tags(tags: List[str]):
     """
     Replace session tags at runtime.
@@ -169,5 +189,6 @@ def stop_instrumenting():
     Client().stop_instrumenting()
 
 
+@check_init
 def create_agent(name: str, agent_id: Optional[str] = None):
     return Client().create_agent(name=name, agent_id=agent_id)

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -418,7 +418,7 @@ class Client(metaclass=MetaClient):
         self._session.end_session(end_state, end_state_reason)
         token_cost = self._worker.end_session(self._session)
 
-        if token_cost == "unknown":
+        if token_cost is None or token_cost == "unknown":
             logger.info("Could not determine cost of run.")
         else:
             token_cost_d = Decimal(token_cost)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,7 +26,6 @@ class TestSessions:
         self.api_key = "random_api_key"
         self.event_type = "test_event_type"
         self.config = agentops.Configuration(api_key=self.api_key, max_wait_time=50)
-        agentops.init(api_key=self.api_key)
 
     def test_session(self, mock_req):
         agentops.start_session(config=self.config)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,10 +26,10 @@ class TestSessions:
         self.api_key = "random_api_key"
         self.event_type = "test_event_type"
         self.config = agentops.Configuration(api_key=self.api_key, max_wait_time=50)
+        agentops.init(api_key=self.api_key)
 
     def test_session(self, mock_req):
         agentops.start_session(config=self.config)
-        print(self.config.api_key)
 
         agentops.record(ActionEvent(self.event_type))
         agentops.record(ActionEvent(self.event_type))


### PR DESCRIPTION
This PR adds a state to __init__.py for tracking whether or not the SDK has been initialized. If it has not been initialized, most functions will not be used.

Fixes an issue where partners are getting logs that there is no active session when they have not called init.