### PR TITLE
Initialize Client.llm_tracker on all codepaths.

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -98,6 +98,7 @@ class Client(metaclass=MetaClient):
             os.environ.get("AGENTOPS_ENV_DATA_OPT_OUT", "False").lower() == "true"
         )
 
+        self.llm_tracker = None
         self.config = None
 
         try:

--- a/agentops/helpers.py
+++ b/agentops/helpers.py
@@ -23,7 +23,8 @@ def singleton(class_):
     instances = {}
 
     def getinstance(*args, **kwargs):
-        if class_ not in instances:
+        allow_multiple_instances = kwargs.pop("allow_multiple_instances", False)
+        if allow_multiple_instances or class_ not in instances:
             instances[class_] = class_(*args, **kwargs)
         return instances[class_]
 

--- a/tests/test_teardown.py
+++ b/tests/test_teardown.py
@@ -20,8 +20,13 @@ class TestSessions:
     def setup_method(self):
         self.api_key = "random_api_key"
         self.event_type = "test_event_type"
-        self.client = Client(self.api_key)
+        self.client = Client(self.api_key, allow_multiple_instances=False)
 
     def test_exit(self):
         # Tests should not hang.
         ...
+
+    def test_can_stop_with_no_instrumentation(self):
+        non_instrumented = Client(self.api_key, instrument_llm_calls=False,
+                                  allow_multiple_instances=True)
+        non_instrumented.stop_instrumenting()

--- a/tests/test_teardown.py
+++ b/tests/test_teardown.py
@@ -29,4 +29,10 @@ class TestSessions:
     def test_can_stop_with_no_instrumentation(self):
         non_instrumented = Client(self.api_key, instrument_llm_calls=False,
                                   allow_multiple_instances=True)
+        assert non_instrumented.llm_tracker is None
         non_instrumented.stop_instrumenting()
+
+    def test_initializes_llm_tracker_when_enabled(self):
+        instrumented = Client(self.api_key, instrument_llm_calls=True,
+                              allow_multiple_instances=True)
+        assert instrumented.llm_tracker is not None


### PR DESCRIPTION
Prevents an issue with the check in stop_instrumenting().
To properly test this, I also needed to add a parameter to override the behavior of singleton.

## 📥 Pull Request

**📘 Description**
Initialize llm_tracker to None when instrument_llm_calls is False.
Add "allow_multiple_instances" kwargs to suppress singleton decorator so the client may be tested.

**🔄 Related Issue (if applicable)**
#256 

**🎯 Goal**
Fix an issue that may occur when Crew and Autogen packages exist but you aren't using them.
(In my case, it popped up in a secondary file's __ main __ section)

**🧪 Testing**
Added a unit test; passed on tox.
