### PR TITLE
revert Apply @check_init to decorators

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -184,16 +184,6 @@ def set_tags(tags: List[str]):
     Client().set_tags(tags)
 
 
-@check_init
-def record_function(event_name: str):
-    return decorators.record_function(event_name)
-
-
-@check_init
-def track_agent(name: Union[str, None] = None):
-    return agent.track_agent(name)
-
-
 def get_api_key() -> str:
     return Client().api_key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Adding @check_init directly to decorators causes a more serious issue than it fixes. Reverting this for now. A more significant overhaul of SDK state will be used to fix this issue
