### PR TITLE
fix `undo_override_ollama`

### DIFF
--- a/agentops/llm_tracker.py
+++ b/agentops/llm_tracker.py
@@ -711,8 +711,9 @@ class LlmTracker:
         completions.AsyncCompletions.create = original_create_async
 
     def undo_override_ollama(self):
-        import ollama
+        if "ollama" in sys.modules:
+            import ollama
 
-        ollama.chat = original_func["ollama.chat"]
-        ollama.Client.chat = original_func["ollama.Client.chat"]
-        ollama.AsyncClient.chat = original_func["ollama.AsyncClient.chat"]
+            ollama.chat = original_func["ollama.chat"]
+            ollama.Client.chat = original_func["ollama.Client.chat"]
+            ollama.AsyncClient.chat = original_func["ollama.AsyncClient.chat"]


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
If you don't have `ollama` installed and you call `stop_instrumenting()`, you will have a crash because undo_override tries to import ollama to undo the override. This change adds a check to see if you have ollama installed.

CLOSES #277 
