### PR TITLE
Fix: Rounding error showing cost

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import traceback
 import logging
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from uuid import UUID, uuid4
 from typing import Optional, List, Union
 
@@ -429,7 +429,7 @@ class Client(metaclass=MetaClient):
                 "This run's cost ${}".format(
                     "{:.2f}".format(token_cost_d)
                     if token_cost_d == 0
-                    else "{:.6f}".format(token_cost_d)
+                    else "{:.6f}".format(token_cost_d.quantize(Decimal('0.000001'), rounding=ROUND_HALF_UP))
                 )
             )
 


### PR DESCRIPTION
📘 Description
The logging of session cost value gave an imprecise decimal value.

🔄 Related Issue (if applicable)
https://github.com/AgentOps-AI/agentops/issues/284

🎯 Goal
Ensure precise and accurate rounding of decimal value when logging Cost of the session

🔍 Additional Context
The quantize method in the decimal module is used to round a Decimal object to a specified precision. It requires a Decimal argument that indicates the desired precision and an optional rounding strategy.

How quantize Works
Precision Specification: By passing a Decimal value that represents the desired precision, we can control the number of decimal places to which the value is rounded. For example, Decimal('0.0000001') specifies that we want to round to six decimal places.
Rounding Strategy: The method supports various rounding strategies. In our case, we used ROUND_HALF_UP, which rounds the number to the nearest neighbor, with ties (a digit exactly in the middle, i.e., 5) rounding up.

🧪 Testing