### PR TITLE
Added indication of what our default end_state is

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -387,7 +387,7 @@ class Client(metaclass=MetaClient):
         End the current session with the AgentOps service.
 
         Args:
-            end_state (str): The final state of the session. Options: Success, Fail, or Indeterminate.
+            end_state (str): The final state of the session. Options: Success, Fail, or Indeterminate (default).
             end_state_reason (str, optional): The reason for ending the session.
             video (str, optional): The video screen recording of the session
             is_auto_end (bool, optional): is this an automatic use of end_session and should be skipped with skip_auto_end_session

--- a/agentops/enums.py
+++ b/agentops/enums.py
@@ -10,6 +10,17 @@ class EventType(Enum):
 
 
 class EndState(Enum):
+    """
+    Enum representing the possible end states of a session.
+
+    Attributes:
+        SUCCESS: Indicates the session ended successfully.
+        FAIL: Indicates the session failed.
+        INDETERMINATE (default): Indicates the session ended with an indeterminate state.
+                       This is the default state if not specified, e.g. if you forget to call end_session()
+                       at the end of your program or don't pass it the end_state parameter
+    """
+
     SUCCESS = "Success"
     FAIL = "Fail"
-    INDETERMINATE = "Indeterminate"
+    INDETERMINATE = "Indeterminate"  # Default


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Added indication of what our default end_state is

**🔄 Related Issue (if applicable)**
Some Discord users aren't aware of why they're getting Indeterminate sessions