### PR TITLE
Implement Tach to define module boundaries

### DIFF
--- a/.github/workflows/tach-check.yml
+++ b/.github/workflows/tach-check.yml
@@ -1,0 +1,25 @@
+
+name: Tach Check
+
+on: [pull_request]
+
+jobs:
+  tach-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'  # Specify the version of Python you need
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tach
+
+    - name: Run Tach
+      run: tach check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ dependencies = [
     "requests==2.31.0",
     "psutil==5.9.8",
     "packaging==23.2",
-    "termcolor==2.4.0"
+    "termcolor==2.4.0",
 ]
 [project.optional-dependencies]
 dev = [
     "pytest==7.4.0",
-    "requests_mock==1.11.0"
+    "requests_mock==1.11.0",
+    "tach==0.6.9",
 ]
 langchain = [
     "langchain~=1.19"

--- a/tach.yml
+++ b/tach.yml
@@ -1,0 +1,95 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.6.9/public/tach-yml-schema.json
+modules:
+  - path: agentops
+    depends_on:
+      - agentops.agent
+      - agentops.client
+      - agentops.config
+      - agentops.decorators
+      - agentops.event
+      - agentops.log_config
+      - agentops.partners
+      - agentops.session
+  - path: agentops.agent
+    depends_on:
+      - agentops
+      - agentops.log_config
+  - path: agentops.client
+    depends_on:
+      - agentops.config
+      - agentops.enums
+      - agentops.event
+      - agentops.exceptions
+      - agentops.helpers
+      - agentops.host_env
+      - agentops.llm_tracker
+      - agentops.log_config
+      - agentops.meta_client
+      - agentops.partners
+      - agentops.session
+  - path: agentops.config
+    depends_on:
+      - agentops.exceptions
+  - path: agentops.decorators
+    depends_on:
+      - agentops
+      - agentops.client
+      - agentops.session
+  - path: agentops.enums
+    depends_on: []
+  - path: agentops.event
+    depends_on:
+      - agentops.enums
+      - agentops.helpers
+  - path: agentops.exceptions
+    depends_on:
+      - agentops.log_config
+  - path: agentops.helpers
+    depends_on:
+      - agentops.log_config
+  - path: agentops.host_env
+    depends_on:
+      - agentops.helpers
+      - agentops.log_config
+  - path: agentops.http_client
+    depends_on:
+      - agentops.log_config
+  - path: agentops.langchain_callback_handler
+    depends_on:
+      - agentops
+      - agentops.helpers
+  - path: agentops.llm_tracker
+    depends_on:
+      - agentops.event
+      - agentops.helpers
+      - agentops.log_config
+      - agentops.session
+  - path: agentops.log_config
+    depends_on: []
+  - path: agentops.meta_client
+    depends_on:
+      - agentops.helpers
+      - agentops.host_env
+      - agentops.http_client
+      - agentops.log_config
+  - path: agentops.partners
+    depends_on:
+      - agentops
+      - agentops.enums
+      - agentops.helpers
+      - agentops.log_config
+  - path: agentops.session
+    depends_on:
+      - agentops.config
+      - agentops.event
+      - agentops.helpers
+      - agentops.http_client
+      - agentops.log_config
+exclude:
+  - .*__pycache__
+  - .*egg-info
+  - docs
+  - examples
+  - tests
+  - venv
+source_root: .


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
This PR introduces [Tach](https://github.com/gauge-sh/tach) to maintain clean module boundaries. It is added as an optional dev dependency and as a CI check in GitHub Actions.

**🎯 Goal**
Particularly for new contributors, it is helpful to have an automatic check to validate that new changes do not violate the intended architecture of the project. Tach also serves as documentation of the logical flow of the project through `tach.yml` and [`tach show`](https://show.gauge.sh/?uid=6ff20934-aa80-4c48-bf6e-7a5771757000)
![image](https://github.com/AgentOps-AI/agentops/assets/10570340/03ca5c50-bfd2-4672-898c-7dafe14c6f19)


**🔍 Additional Context**
https://docs.gauge.sh

If changes are made which introduce new cross-module dependencies, they will cause `tach check` to fail and point out the offending imports. If they represent an intentional design change, they can be acknowledged with `tach sync`.

**🧪 Testing**
Running `tach check` passes with this configuration.
