### PR TITLE
recursion error

### DIFF
--- a/agentops/session.py
+++ b/agentops/session.py
@@ -134,7 +134,7 @@ class Session:
 
                 event.trigger_event_id = event.trigger_event.id
                 event.trigger_event_type = event.trigger_event.event_type
-                self.record(event.trigger_event)
+                self._add_event(event.trigger_event.__dict__)
                 event.trigger_event = None  # removes trigger_event from serialization
 
         self._add_event(event.__dict__)

--- a/agentops/session.py
+++ b/agentops/session.py
@@ -134,7 +134,7 @@ class Session:
 
                 event.trigger_event_id = event.trigger_event.id
                 event.trigger_event_type = event.trigger_event.event_type
-                self.record(event)
+                self.record(event.trigger_event)
                 event.trigger_event = None  # removes trigger_event from serialization
 
         self._add_event(event.__dict__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentops"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
When attempting to record an error event associated with another event, we are currently unintentionally recording the parent event again until max recursion depth is reached,

Changes one line to record the associated event, not record the error.