### PR TITLE
bugfix: 291 - llm_tracker is not an attribute in client class

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -95,8 +95,9 @@ class Client(metaclass=MetaClient):
             os.environ.get("AGENTOPS_ENV_DATA_OPT_OUT", "False").lower() == "true"
         )
 
+        self.llm_tracker = None
+        
         self.config = None
-
         try:
             self.config = ClientConfiguration(
                 api_key=api_key,


### PR DESCRIPTION
📘 Description
initialize the llm_tracker in class client with None

🔄 Related Issue (if applicable)
https://github.com/AgentOps-AI/agentops/issues/291

🎯 Goal
fix the bug, that the client class has in some cases no attribute for llm_tracker.

🔍 Additional Context
Looks like the class init is not complete processed and the attribute did not been created in some circumstances?

🧪 Testing
Fix in local environment, re-run the crewai application with agentops in two modes.
a) enabled
b) disabled.