### PR TITLE
check ao version and warn for update

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional, List, Union
 from .client import Client
 from .event import Event, ActionEvent, LLMEvent, ToolEvent, ErrorEvent
 from .decorators import record_function, track_agent
+from .helpers import check_agentops_update
 from .log_config import logger
 from .session import Session
 
@@ -61,6 +62,8 @@ def init(
     Attributes:
     """
     Client().unsuppress_logs()
+    check_agentops_update()
+
     if Client().is_initialized:
         return logger.warning("AgentOps has already been initialized")
 

--- a/agentops/helpers.py
+++ b/agentops/helpers.py
@@ -158,7 +158,7 @@ def check_agentops_update():
         parts = line.split()
         if len(parts) > 0 and parts[0] == "agentops":
             logger.warning(
-                f" WARNING: {parts[0]} is out of date. Please update with the command: 'pip install --upgrade {parts[0]}'"
+                f" WARNING: {parts[0]} is out of date. Please update with the command: 'pip install --upgrade agentops'"
             )
 
 

--- a/agentops/helpers.py
+++ b/agentops/helpers.py
@@ -8,6 +8,7 @@ from typing import Union
 from .log_config import logger
 from uuid import UUID
 from importlib.metadata import version
+import subprocess
 
 ao_instances = {}
 
@@ -146,6 +147,19 @@ def get_agentops_version():
     except Exception as e:
         logger.warning("Error reading package version: %s", e)
         return None
+
+
+def check_agentops_update():
+    result = subprocess.run(
+        ["pip", "list", "--outdated"], capture_output=True, text=True
+    )
+    lines = result.stdout.splitlines()[2:]  # Skip the header lines
+    for line in lines:
+        parts = line.split()
+        if len(parts) > 0 and parts[0] == "agentops":
+            logger.warning(
+                f" WARNING: {parts[0]} is out of date. Please update with the command: 'pip install --upgrade {parts[0]}'"
+            )
 
 
 # Function decorator that prints function name and its arguments to the console for debug purposes


### PR DESCRIPTION
On `.init()` checks if the agentops version is out of date and if it is, logs a warning.