### PR TITLE
fix: speed up version check

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -8,6 +8,7 @@ from .decorators import record_function, track_agent
 from .helpers import check_agentops_update
 from .log_config import logger
 from .session import Session
+import threading
 
 try:
     from .partners.langchain_callback_handler import (
@@ -62,7 +63,8 @@ def init(
     Attributes:
     """
     Client().unsuppress_logs()
-    check_agentops_update()
+    t = threading.Thread(target=check_agentops_update)
+    t.start()
 
     if Client().is_initialized:
         return logger.warning(

--- a/tests/core_manual_tests/canary.py
+++ b/tests/core_manual_tests/canary.py
@@ -1,0 +1,25 @@
+import agentops
+from openai import OpenAI
+from dotenv import load_dotenv
+from agentops import ActionEvent
+
+load_dotenv()
+agentops.init()
+openai = OpenAI()
+
+messages = [{"role": "user", "content": "Hello"}]
+
+# option 1: use session.patch
+response = openai.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+    temperature=0.5,
+)
+
+agentops.record(ActionEvent(action_type="test event"))
+
+agentops.end_session(end_state="Success")
+
+###
+#  Used to verify that one session is created with one LLM event
+###


### PR DESCRIPTION
The agentops version check was halting execution of other code and using the pip CLI.
Switching to the PyPi API and running on a separate thread fixes this.