### PR TITLE
fix: update notebooks

### DIFF
--- a/examples/multi_agent_example.ipynb
+++ b/examples/multi_agent_example.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "import agentops\n",
-    "from agentops.agent import track_agent\n",
+    "from agentops import track_agent\n",
     "from dotenv import load_dotenv\n",
     "import os\n",
     "from openai import OpenAI\n",
@@ -297,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/examples/multi_agent_groq_example.ipynb
+++ b/examples/multi_agent_groq_example.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "import agentops\n",
-    "from agentops.agent import track_agent\n",
+    "from agentops import track_agent\n",
     "from dotenv import load_dotenv\n",
     "import os\n",
     "from groq import Groq\n",


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Two of the example notebooks imports `track_agent()` from `agentops.agent` instead of just `agentops`. In 0.3.5, the `agents.py` was removed and the functionality moved to `decorators.py` so this import no longer works. It was never necessary to use `agentops.agent` instead of `agentops`, so this change shouldn't affect older versions.