### PR TITLE
decorator page name fix

### DIFF
--- a/docs/v1/concepts/decorators.mdx
+++ b/docs/v1/concepts/decorators.mdx
@@ -16,8 +16,14 @@ If your implementation uses Classes to denote Agents, this decorator enables aut
 
 Learn more about tracking agents [here](/v1/usage/tracking-agents).
 
-## `@track_function()`
+## `@record_action()`
 Sometimes your agent system will use functions that are important to track as [`Actions`](/v1/concepts/events/#actionevent).
+
+Adding this decorator above any function will allow every instance of that function call to be tracked and displayed
+in your [Session](v1/concepts/sessions) Drill-Down on the dashboard.
+
+## `@record_tool()`
+Some functions are used as Tools. If you're not using an agent framework that records [`ToolEvents`](/v1/concepts/events/#toolevent) with AgentOps automatically, this decorator will record `ToolEvents` when the function is called.
 
 Adding this decorator above any function will allow every instance of that function call to be tracked and displayed
 in your [Session](v1/concepts/sessions) Drill-Down on the dashboard.


### PR DESCRIPTION
`@record_function` was improperly named as `@track_function` which has been changed to `@record_action` anyway.