### PR TITLE
fix rlock issue

### DIFF
--- a/agentops/session.py
+++ b/agentops/session.py
@@ -268,7 +268,7 @@ class Session:
         if not self.is_running:
             return
         with self.lock:
-            queue_copy = copy.deepcopy(self.queue)  # Copy the current items
+            queue_copy = self.queue[:]  # Copy the current items
             self.queue = []
 
             if len(queue_copy) > 0:


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Deepcopy fails when there are non-pickleable objects in the "queue". Because events often contain "self" of some user created objects, we cannot be sure there are no non-pickleable objects. Simple copy should be sufficient here
