### PR TITLE
event decorators have default names

### DIFF
--- a/agentops/decorators.py
+++ b/agentops/decorators.py
@@ -17,7 +17,7 @@ def record_function(event_name: str):
     return record_action(event_name)
 
 
-def record_action(event_name: str):
+def record_action(event_name: Optional[str] = None):
     """
     Decorator to record an event before and after a function call.
     Usage:
@@ -25,7 +25,7 @@ def record_action(event_name: str):
                     function being decorated. Additionally, timing information about
                     the action is recorded
     Args:
-            event_name (str): The name of the event to record.
+            event_name (optional, str): The name of the event to record.
     """
 
     def decorator(func):
@@ -53,11 +53,16 @@ def record_action(event_name: str):
                 arg_values.update(dict(zip(arg_names, args)))
                 arg_values.update(kwargs)
 
+                if not event_name:
+                    action_type = func.__name__
+                else:
+                    action_type = event_name
+
                 event = ActionEvent(
                     params=arg_values,
                     init_timestamp=init_time,
                     agent_id=check_call_stack_for_agent_id(),
-                    action_type=event_name,
+                    action_type=action_type,
                 )
 
                 try:
@@ -114,11 +119,16 @@ def record_action(event_name: str):
                 arg_values.update(dict(zip(arg_names, args)))
                 arg_values.update(kwargs)
 
+                if not event_name:
+                    action_type = func.__name__
+                else:
+                    action_type = event_name
+
                 event = ActionEvent(
                     params=arg_values,
                     init_timestamp=init_time,
                     agent_id=check_call_stack_for_agent_id(),
-                    action_type=event_name,
+                    action_type=action_type,
                 )
 
                 try:

--- a/agentops/decorators.py
+++ b/agentops/decorators.py
@@ -163,7 +163,7 @@ def record_action(event_name: Optional[str] = None):
     return decorator
 
 
-def record_tool(tool_name: str):
+def record_tool(tool_name: Optional[str] = None):
     """
     Decorator to record a tool use event before and after a function call.
     Usage:
@@ -199,11 +199,16 @@ def record_tool(tool_name: str):
                 arg_values.update(dict(zip(arg_names, args)))
                 arg_values.update(kwargs)
 
+                if not tool_name:
+                    name = func.__name__
+                else:
+                    name = tool_name
+
                 event = ToolEvent(
                     params=arg_values,
                     init_timestamp=init_time,
                     agent_id=check_call_stack_for_agent_id(),
-                    name=tool_name,
+                    name=name,
                 )
 
                 try:
@@ -260,11 +265,16 @@ def record_tool(tool_name: str):
                 arg_values.update(dict(zip(arg_names, args)))
                 arg_values.update(kwargs)
 
+                if not tool_name:
+                    name = func.__name__
+                else:
+                    name = tool_name
+
                 event = ToolEvent(
                     params=arg_values,
                     init_timestamp=init_time,
                     agent_id=check_call_stack_for_agent_id(),
-                    name=tool_name,
+                    name=name,
                 )
 
                 try:

--- a/agentops/decorators.py
+++ b/agentops/decorators.py
@@ -171,7 +171,7 @@ def record_tool(tool_name: Optional[str] = None):
                     function being decorated. Additionally, timing information about
                     the action is recorded
     Args:
-            tool_name (str): The name of the event to record.
+            tool_name (optional, str): The name of the event to record.
     """
 
     def decorator(func):

--- a/tests/test_record_action.py
+++ b/tests/test_record_action.py
@@ -67,6 +67,27 @@ class TestRecordAction:
 
         agentops.end_session(end_state="Success")
 
+    def test_record_action_default_name(self, mock_req):
+        agentops.start_session()
+
+        @record_action()
+        def add_two(x, y):
+            return x + y
+
+        # Act
+        add_two(3, 4)
+        time.sleep(0.1)
+
+        # Assert
+        assert len(mock_req.request_history) == 2
+        assert mock_req.last_request.headers["X-Agentops-Api-Key"] == self.api_key
+        request_json = mock_req.last_request.json()
+        assert request_json["events"][0]["action_type"] == "add_two"
+        assert request_json["events"][0]["params"] == {"x": 3, "y": 4}
+        assert request_json["events"][0]["returns"] == 7
+
+        agentops.end_session(end_state="Success")
+
     def test_record_action_decorator_multiple(self, mock_req):
         agentops.start_session()
 

--- a/tests/test_record_tool.py
+++ b/tests/test_record_tool.py
@@ -68,6 +68,27 @@ class TestRecordTool:
 
         agentops.end_session(end_state="Success")
 
+    def test_record_tool_default_name(self, mock_req):
+        agentops.start_session()
+
+        @record_tool()
+        def add_two(x, y):
+            return x + y
+
+        # Act
+        add_two(3, 4)
+        time.sleep(0.1)
+
+        # Assert
+        assert len(mock_req.request_history) == 2
+        assert mock_req.last_request.headers["X-Agentops-Api-Key"] == self.api_key
+        request_json = mock_req.last_request.json()
+        assert request_json["events"][0]["name"] == "add_two"
+        assert request_json["events"][0]["params"] == {"x": 3, "y": 4}
+        assert request_json["events"][0]["returns"] == 7
+
+        agentops.end_session(end_state="Success")
+
     def test_record_tool_decorator_multiple(self, mock_req):
         agentops.start_session()
 


### PR DESCRIPTION
@record_action and @record_tool both will use the function's name as the default event name if none is supplied.

Tests