### PR TITLE
[do not merge] migrate build system to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "agentops"
 version = "0.3.14"
+
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },
@@ -45,3 +46,9 @@ max_line_length = 120
 
 [project.scripts]
 agentops = "agentops.cli:main"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["agentops"]


### PR DESCRIPTION
Fixes #473 

---

### Why Hatch?
[Why hatch?](https://hatch.pypa.io/latest/why/)

### Who Uses Hatch?
- [Quivr](https://github.com/QuivrHQ/quivr/blob/main/core/pyproject.toml)

### Migrating from Setuptools to Hatch: Is It Safe?
- Yes, Hatchling is compatible with modern PEP standards (e.g., PEP 517 and 518).

### Does It Require Me to Install Extra Dependencies?
- No. `pip` automatically resolves Hatchling in a temporary environment for the build if isolated builds are enabled (typically the default). This is similar behavior to setuptools and other PEP-compliant build backends specified in `pyproject.toml`.

### When Hatch May Not Be Ideal
- Hatch may not be ideal for projects involving complex builds, such as those compiling C or other extension modules, due to limited support for handling compiled dependencies. (Not relevant for this project)

### Before Merging: Feedback Loop
Let's keep this PR open for feedback from peers to measure its broader impact. Although several tests have been conducted, ensuring that #473 isn’t an issue unique to one setup is essential. Otherwise, we should consider if investing more time into troubleshooting `setuptools` is worth it.

---

### TODO Tasks:
- [ ] Review and gather feedback from peers @areibman @siyangqiu 
- [ ] Confirm compatibility with CI (e.g., Tox).
- [ ] Validate the impact across different environments.
- [ ] Ensure no critical build failures or edge cases emerge.
- [ ] Document any specific configuration changes needed for CI integration.