### PR TITLE
feat: create integration between entelligence and agentops repository

### DIFF
--- a/docs/v1/scripts/entelligence.js
+++ b/docs/v1/scripts/entelligence.js
@@ -1,0 +1,37 @@
+function initEntelligence() {
+  const script = document.getElementById("entelligence-chat");
+
+  if (!script) {
+    const chatScript = document.createElement("script");
+    chatScript.type = "module";
+    chatScript.id = "entelligence-chat";
+    chatScript.src =
+      "https://d345f39z3arwqc.cloudfront.net/entelligence-chat.js";
+
+    // Create initialization script
+    const initScript = document.createElement("script");
+    initScript.type = "module";
+    initScript.textContent = `
+    window.EntelligenceChat.init({
+      analyticsData: {
+        repoName: "agentops",
+        organization: "AgentOps-AI", 
+        apiKey: "1234567890",
+        theme: 'dark'
+      }
+    });
+  `;
+
+    // Append initialization script after chat script loads
+    chatScript.onload = () => {
+      document.body.appendChild(initScript);
+    };
+
+    // Append chat script to the body
+    document.body.appendChild(chatScript);
+  }
+}
+
+window.addEventListener("load", function () {
+  initEntelligence();
+});

--- a/docs/v1/styles/styles.css
+++ b/docs/v1/styles/styles.css
@@ -158,3 +158,22 @@
   padding: 0;
   margin: 0;
 }
+
+.hidden {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .lg\:block {
+    display: block;
+  }
+  .lg\:hidden {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:block {
+    display: block;
+  }
+}


### PR DESCRIPTION
In this feature we're adding the pop up chat of entelligence inside the agentops repository

## 📥 Pull Request

**📘 Description**

Chat Widget Integration

This PR adds the Entelligence chat widget integration to our documentation site. The changes include:

- Added initialization script for the Entelligence chat widget
- Configured analytics data with repository and organization information
- Set up automatic widget loading on page load
- Implemented dark theme configuration

The widget will be loaded from the CloudFront CDN and initialized with our organization's settings.

Technical Details
- Script is loaded asynchronously to prevent blocking page rendering
- Initialization occurs only if the widget hasn't been previously loaded
- Analytics configuration includes repo name, organization, and API key

