### PR TITLE
allow termcolor >=2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "requests>=2.0.0,<3.0.0",
     "psutil>=5.9.8",
     "packaging==23.2",
-    "termcolor~=2.4.0", # 2.x.x tolerant
+    "termcolor>=2.3.0", # 2.x.x tolerant
     "PyYAML>=5.3,<7.0"
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
# 🔍 Review Summary 
 - **Purpose**:
   Update `termcolor` dependency version constraint in `pyproject.toml` to allow for greater flexibility in compatible versions.
- **Key Changes**:
   - **Enhancement**: Updated `termcolor` dependency version constraint from `~2.4.0` to `>=2.3.0`.
- **Impact**:
   Enhances project's adaptability to a broader range of `termcolor` versions, potentially reducing dependency conflicts. 



<details><summary>Original Description</summary>

No existing description found

</details>