### PR TITLE
Fix packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,6 @@ exclude = [
     "venv",
     "tests/core_manual_tests",
 ]
+
+[tool.setuptools]
+packages = ["agentops"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "tach~=0.9",
 ]
 langchain = [
-    "langchain==0.2.14"
+    "langchain==0.2.14; python_version >= '3.8.1'"
 ]
 
 [project.urls]


### PR DESCRIPTION
1. Explicit packages definition; fixes global package install error

```

➜  agentops git:(otel-exporter) uv sync --all-extras
Resolved 75 packages in 2.08s
  × Failed to build `agentops @ file:///Users/noob/agentops`
  ╰─▶ Build backend failed to determine requirements with `build_editable()` (exit status: 1)

      [stderr]
      error: Multiple top-level packages discovered in a flat-layout: ['dev', 'agentops'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.

```


2. Fixes #524 



3. profit: `uv sync --all-extras` now passes