### PR TITLE
Reorganize Dependencies and CI packaging

### DIFF
--- a/.github/workflows/tach-check.yml
+++ b/.github/workflows/tach-check.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tach
+        pip install ".[ci]"
 
     - name: Run Tach
       run: tach check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,14 @@ dependencies = [
     "opentelemetry-sdk>=1.22.0,<2.0.0", # SDK for implementation
     "opentelemetry-exporter-otlp-proto-http>=1.22.0,<2.0.0", # For OTLPSpanExporter
 ]
+
 [project.optional-dependencies]
+langchain = [
+    "langchain==0.2.14; python_version >= '3.8.1'"
+]
+
+
+[dependency-groups]
 dev = [
     "pytest==7.4.0",
     "pytest-depends",
@@ -42,9 +49,7 @@ dev = [
     "tach~=0.9",
     "vcrpy>=6.0.0; python_version >= '3.8'"
 ]
-langchain = [
-    "langchain==0.2.14; python_version >= '3.8.1'"
-]
+
 
 [project.urls]
 Homepage = "https://github.com/AgentOps-AI/agentops"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,12 @@ dev = [
     "pyfakefs",
     "requests_mock==1.11.0",
     "ruff",
-    "tach~=0.9",
     "vcrpy>=6.0.0; python_version >= '3.8'"
+]
+
+
+ci = [
+    "tach~=0.9",
 ]
 
 


### PR DESCRIPTION
Fixes #539

## Details
- Created a new `[dependency-groups]` to follow [PEP 735](https://peps.python.org/pep-0735/#why-not-support-dependency-group-includes-in-project-dependencies-or-project-optional-dependencies)
- Moved `tach` package from `dev` dependencies to a dedicated `ci` group
- Updated GitHub action `tach-check`  to use `pip install ".[ci]"` which installs the package with CI dependencies

## Testing
- CI workflow should continue to run successfully with the new dependency structure
- Development environment setup remains unchanged
