### PR TITLE
Loosen Dependency Restriction for packaging Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "requests>=2.0.0,<3.0.0",
     "psutil==5.9.8",
-    "packaging==23.2",
+    "packaging>=23.2",
     "termcolor>=2.3.0", # 2.x.x tolerant
     "PyYAML>=5.3,<7.0",
     "opentelemetry-api>=1.22.0,<2.0.0", # API for interfaces


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
I’ve encountered an issue where the fixed dependency on packaging version 23.2 in AgentOps (version 0.3.12) causes conflicts with other packages that require a different version of packaging.

Would it be possible to update the dependency to allow a range of versions for packaging instead of fixing it to 23.2? For example, using packaging>=23.0 would provide greater flexibility while ensuring compatibility.

close https://github.com/AgentOps-AI/agentops/issues/555

**🧪 Testing**
_Describe the tests you performed to validate your changes._

