### PR TITLE
deps: remove `packaging`; unpinned & ranged versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,8 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.0.0,<3.0.0",
-    "psutil==5.9.8",
-    "packaging==23.2",
-    "termcolor>=2.3.0", # 2.x.x tolerant
+    "psutil>=5.9.8,<6.1.0",
+    "termcolor>=2.3.0,<2.5.0",
     "PyYAML>=5.3,<7.0",
     "opentelemetry-api>=1.22.0,<2.0.0", # API for interfaces
     "opentelemetry-sdk>=1.22.0,<2.0.0", # SDK for implementation


### PR DESCRIPTION
Closes #545
Closes #556
Fixes #555


---


- `packaging` does not have to be verbosely specified because:
  1. It is already an implicity dependency upon `setuptools`
  2. Even if the above wouldn't be true, it still would not belong under runtime `[dependencies]`. 
  For further info, https://packaging.python.org/

- Restored loosen `psutil` loosen dep from #491

- Capped all dependencies to a maximum ver. pointing to the latest stable (there are a number of reasons to do that, among security and also performance)


