### PR TITLE
GH Actions: fix the pipeline

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -1,6 +1,7 @@
 name: Python Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -25,13 +25,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7,3.8,3.9,3.10,3.11,3.12]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
+          cache: 'pip'
           python-version: '3.11' # Use a default Python version for running tox
       - name: Install tox
         run: pip install tox

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - '**/*.py'
 
+  workflow_dispatch:
 permissions:
   contents: read
 
@@ -33,30 +34,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        id: setup_python
+      - uses: astral-sh/setup-uv@v4
         with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
           python-version: "3.11.10"
-
-      - name: UV Cache
-        # Manually cache the uv cache directory
-        # until setup-python supports it:
-        # https://github.com/actions/setup-python/issues/822
-        uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install packages
         run: |
-          python -m pip install -U uv pre-commit
-          uv pip install --upgrade --system -e .[dev]
+          uv sync --group dev
 
       - name: Run pre-commit
         run: |
-          pre-commit run --show-diff-on-failure --color=always --all-files
+          uvx pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/tach-check.yml
+++ b/.github/workflows/tach-check.yml
@@ -1,6 +1,7 @@
 name: Tach Check
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '**/*.py'
@@ -12,17 +13,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: astral-sh/setup-uv@v4
       with:
-        python-version: '3.11'  # Specify the version of Python you need
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install ".[ci]"
+        uv sync --group ci
 
     - name: Run Tach
-      run: tach check
+      run: uvx tach check

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py311
+env_list =
+    3.13
+    3.12
+    3.11
+    3.10
+    3.9
+    3.8
+    3.7
+; skip_missing_interpreters = true
 
 [testenv]
 deps = 


### PR DESCRIPTION
# UV Integration and Workflow Improvements

This PR updates our GitHub Actions workflows to use absolute [uv](https://github.com/astral-sh/setup-uv) managed runtime for the actions listed below.

It also fixes the python tests action which in despite of running on a matrix of runtimes, all environments used python 3.11.

## Key Changes

### Static Analysis Workflow
- Added manual trigger support via `workflow_dispatch` (try `gh workflow run`)
- Packages are installed with `uv sync --group dev`
- Replaced `actions/setup-python` with `astral-sh/setup-uv@v4`
 
    > [Do I still need actions/setup-python alongside setup-uv?](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#faq)
- Removed DIY UV cache, let setup-uv handle it

    > This was preiovusly done with intent to support system-installed python `actions/setup-python`


Actions checklist:

- [ ]  add-notebook-examples-to-docs.yml
- [ ]  codecov.yml
- [ ]  python-publish.yml
- [ ]  python-testing.yml
- [x]  static-analysis.yaml
- [x]  tach-check.yml
- [ ]  test-notebooks.yml
