### PR TITLE
lint: pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dev = [
     "pytest-vcr",
     "pytest-mock",
     "pyfakefs",
-     "requests_mock==1.11.0",
-     "ruff",
-     "vcrpy>=6.0.0; python_version >= '3.8'"
+    "requests_mock==1.11.0",
+    "ruff",
+    "vcrpy>=6.0.0; python_version >= '3.8'"
  ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Quick fix on `pyproject.toml` [just in case] to avoid any eventual package managers complaining about format