### PR TITLE
[CI] Add a new action to check for stale PRs

### DIFF
--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -5,10 +5,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
-  check-stale-pr:
+  stale-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -1,0 +1,45 @@
+name: 'Check for Stale PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-stale-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Only process pull requests (not issues)
+          days-before-stale: 14
+          days-before-close: 7
+          
+          # Only target PRs
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          
+          # Custom messages
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had any activity in the last 14 days.
+            
+            @${{ github.event.pull_request.user.login }} please review this PR and make any necessary updates.
+            
+            If no updates are made within 7 days, this PR will be automatically closed.
+          
+          close-pr-message: |
+            This pull request has been automatically closed because it has been stale for 7 days with no activity.
+            
+            Feel free to reopen this PR if you'd like to continue working on it.
+          
+          # Labels
+          stale-pr-label: 'stale'
+          
+          # Remove stale label on PR update
+          remove-stale-when-updated: true
+          
+          # Don't remove any existing labels
+          labels-to-remove-when-stale: ''
+          labels-to-remove-when-unstale: ''


### PR DESCRIPTION
# 📥 [CI] Add a new action to check for stale PRs

## PR actions
1. PR is marked with the stale label if no commits are made in 14 days.
2. PR is closed 7 days after being marked stale.
3. When the PR is labelled stale an appropriate comment is added to the PR by tagging the author.
4. When the PR is closed the comment is added to the PR that its closed and can be reopened if required.
5. If there is a commit from anyone in the PR the CI removes the stale label and resets the timer of the days until it's marked stale.
6. No other labels are removed by the CI action so that we can search for them easily.

