### PR TITLE
Add docs videos for OpenAI and Anthropic

### DIFF
--- a/docs/v1/integrations/anthropic.mdx
+++ b/docs/v1/integrations/anthropic.mdx
@@ -9,7 +9,15 @@ import EnvTooltip from '/snippets/add-env-tooltip.mdx'
 [Anthropic AI](https://www.anthropic.com) is a leading provider of AI tools and services, including the Claude, Haiku, and Sonnet series of models.
 Explore the [Anthropic API](https://docs.anthropic.com/en/home) for more information.
 
-# Steps to integrate Anthropic with AgentOps
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/Yx2Crpbms7I"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
 
 <Steps>
   <Step title="Install the AgentOps SDK">

--- a/docs/v1/integrations/openai.mdx
+++ b/docs/v1/integrations/openai.mdx
@@ -6,9 +6,18 @@ description: "AgentOps provides first class support for OpenAI's GPT family of m
 import CodeTooltip from '/snippets/add-code-tooltip.mdx'
 import EnvTooltip from '/snippets/add-env-tooltip.mdx'
 
-<Card title="OpenAI" icon="robot" href="https://www.openai.com">
-    First class support for GPT family of models
-</Card>
+[OpenAI](https://www.openai.com) is a leading provider of AI tools and services.
+Explore the [OpenAI API](https://platform.openai.com/) for more information.
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/qlotcZSh5_0"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
 
 <Steps>
   <Step title="Install the AgentOps SDK">


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Release Note

**Purpose**:
- Enhance documentation with interactive and visual instructions for Anthropic and OpenAI integrations in AgentOps.

**Changes**:

- **Documentation**:
  - Added a YouTube video to `docs/v1/integrations/anthropic.mdx` for Anthropic integration guidance.
  - Replaced card element with a YouTube video in `docs/v1/integrations/openai.mdx` for improved OpenAI integration instructions.

**Impact**:
- Improved user understanding and ease of integrating AI services with AgentOps through enhanced visual documentation. 



<details><summary>Original Description</summary>

## 📥 Pull Request

**📘 Description**
Adding YouTube docs videos to OpenAI and Anthropic integrations pages in the Mintlify docs site

https://www.youtube.com/watch?v=qlotcZSh5_0 AgentOps x OpenAI
https://www.youtube.com/watch?v=Yx2Crpbms7I AgentOps x Anthropic


**🧪 Testing**
Screenshots included
<img width="1693" alt="Screenshot 2024-12-20 at 7 51 33 PM" src="https://github.com/user-attachments/assets/336edb3b-42c6-47ac-8070-073b998f5e50" />
<img width="1694" alt="Screenshot 2024-12-20 at 7 48 07 PM" src="https://github.com/user-attachments/assets/1f93a2af-a005-4f67-b59b-ae411fc61548" />


</details>