### PR TITLE
Replace usage of functools.cached_property with DIY class for backwar…

### DIFF
--- a/agentops/client.py
+++ b/agentops/client.py
@@ -29,6 +29,7 @@ from .session import Session, active_sessions
 from .singleton import conditional_singleton
 from .helpers import cached_property
 
+
 @conditional_singleton
 class Client(metaclass=MetaClient):
     def __init__(self):

--- a/agentops/client.py
+++ b/agentops/client.py
@@ -14,7 +14,6 @@ import sys
 import threading
 import traceback
 from decimal import Decimal
-from functools import cached_property
 from typing import List, Optional, Tuple, Union
 from uuid import UUID, uuid4
 
@@ -28,7 +27,7 @@ from .log_config import logger
 from .meta_client import MetaClient
 from .session import Session, active_sessions
 from .singleton import conditional_singleton
-
+from .helpers import cached_property
 
 @conditional_singleton
 class Client(metaclass=MetaClient):

--- a/agentops/helpers.py
+++ b/agentops/helpers.py
@@ -182,6 +182,7 @@ class cached_property:
     property cached on the instance.
     See: https://github.com/AgentOps-AI/agentops/issues/612
     """
+
     def __init__(self, func):
         self.func = func
         self.__doc__ = func.__doc__
@@ -191,4 +192,4 @@ class cached_property:
             return self
         value = self.func(instance)
         setattr(instance, self.func.__name__, value)
-        return value 
+        return value

--- a/agentops/helpers.py
+++ b/agentops/helpers.py
@@ -174,3 +174,21 @@ def debug_print_function_params(func):
         return func(self, *args, **kwargs)
 
     return wrapper
+
+
+class cached_property:
+    """
+    Decorator that converts a method with a single self argument into a
+    property cached on the instance.
+    See: https://github.com/AgentOps-AI/agentops/issues/612
+    """
+    def __init__(self, func):
+        self.func = func
+        self.__doc__ = func.__doc__
+
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+        value = self.func(instance)
+        setattr(instance, self.func.__name__, value)
+        return value 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,64 +1,67 @@
 import pytest
 from agentops.helpers import cached_property
 
+
 def test_cached_property():
     class TestClass:
         def __init__(self):
             self.compute_count = 0
-            
+
         @cached_property
         def expensive_computation(self):
             self.compute_count += 1
             return 42
-    
+
     # Create instance
     obj = TestClass()
-    
+
     # First access should compute the value
     assert obj.expensive_computation == 42
     assert obj.compute_count == 1
-    
+
     # Second access should use cached value
     assert obj.expensive_computation == 42
     assert obj.compute_count == 1  # Count shouldn't increase
-    
+
     # Third access should still use cached value
     assert obj.expensive_computation == 42
     assert obj.compute_count == 1  # Count shouldn't increase
+
 
 def test_cached_property_different_instances():
     class TestClass:
         def __init__(self):
             self.compute_count = 0
-            
+
         @cached_property
         def expensive_computation(self):
             self.compute_count += 1
             return id(self)  # Return unique id for each instance
-    
+
     # Create two different instances
     obj1 = TestClass()
     obj2 = TestClass()
-    
+
     # Each instance should compute its own value
     val1 = obj1.expensive_computation
     val2 = obj2.expensive_computation
-    
+
     assert val1 != val2  # Values should be different
     assert obj1.compute_count == 1
     assert obj2.compute_count == 1
-    
+
     # Accessing again should use cached values
     assert obj1.expensive_computation == val1
     assert obj2.expensive_computation == val2
     assert obj1.compute_count == 1  # Counts shouldn't increase
     assert obj2.compute_count == 1
 
+
 def test_cached_property_class_access():
     class TestClass:
         @cached_property
         def expensive_computation(self):
             return 42
-    
+
     # Accessing via class should return the descriptor
-    assert isinstance(TestClass.expensive_computation, cached_property) 
+    assert isinstance(TestClass.expensive_computation, cached_property)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,64 @@
+import pytest
+from agentops.helpers import cached_property
+
+def test_cached_property():
+    class TestClass:
+        def __init__(self):
+            self.compute_count = 0
+            
+        @cached_property
+        def expensive_computation(self):
+            self.compute_count += 1
+            return 42
+    
+    # Create instance
+    obj = TestClass()
+    
+    # First access should compute the value
+    assert obj.expensive_computation == 42
+    assert obj.compute_count == 1
+    
+    # Second access should use cached value
+    assert obj.expensive_computation == 42
+    assert obj.compute_count == 1  # Count shouldn't increase
+    
+    # Third access should still use cached value
+    assert obj.expensive_computation == 42
+    assert obj.compute_count == 1  # Count shouldn't increase
+
+def test_cached_property_different_instances():
+    class TestClass:
+        def __init__(self):
+            self.compute_count = 0
+            
+        @cached_property
+        def expensive_computation(self):
+            self.compute_count += 1
+            return id(self)  # Return unique id for each instance
+    
+    # Create two different instances
+    obj1 = TestClass()
+    obj2 = TestClass()
+    
+    # Each instance should compute its own value
+    val1 = obj1.expensive_computation
+    val2 = obj2.expensive_computation
+    
+    assert val1 != val2  # Values should be different
+    assert obj1.compute_count == 1
+    assert obj2.compute_count == 1
+    
+    # Accessing again should use cached values
+    assert obj1.expensive_computation == val1
+    assert obj2.expensive_computation == val2
+    assert obj1.compute_count == 1  # Counts shouldn't increase
+    assert obj2.compute_count == 1
+
+def test_cached_property_class_access():
+    class TestClass:
+        @cached_property
+        def expensive_computation(self):
+            return 42
+    
+    # Accessing via class should return the descriptor
+    assert isinstance(TestClass.expensive_computation, cached_property) 


### PR DESCRIPTION
Fixes #612 

### Changes

1. Removed the import of `cached_property` from functools
2. Added a custom `cached_property` implementation that works in Python 3.7+
3. The rest of the file can remain unchanged since it will use our custom implementation

This implementation provides the same functionality as the built-in `cached_property` but works in Python 3.7. The property will be computed once when first accessed and then cached on the instance for subsequent accesses.


### Testing

1. Tests basic caching functionality - verifies that the computation only happens once
2. Tests that different instances maintain separate cached values
3. Tests class-level access to the descriptor

The tests verify that:
- The decorated property caches its value after first computation
- The cache is instance-specific
- Multiple accesses don't trigger recomputation
- The decorator works correctly when accessed via the class itself
