### PR TITLE
feat: add Python version compatibility layer for importlib.metadata

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -1,17 +1,19 @@
 # agentops/__init__.py
 import sys
 from typing import Optional, List, Union
+from .helpers import import_module
+
+# Get version from compat
+version = import_module("importlib.metadata.version")
+from packaging import version
 
 from .client import Client
 from .event import Event, ActionEvent, LLMEvent, ToolEvent, ErrorEvent
 from .decorators import record_action, track_agent, record_tool, record_function
-from .helpers import check_agentops_update
+from .helpers import check_agentops_update, import_module
 from .log_config import logger
 from .session import Session
 import threading
-from importlib.metadata import version as get_version
-from packaging import version
-from .llms import tracker
 
 try:
     from .partners.langchain_callback_handler import (

--- a/agentops/host_env.py
+++ b/agentops/host_env.py
@@ -1,11 +1,15 @@
 import platform
 import psutil
 import socket
-from .helpers import get_agentops_version
+from .helpers import get_agentops_version, import_module
 from .log_config import logger
-import importlib.metadata
 import os
 import sys
+
+# Get imports for this module
+version = import_module("importlib.metadata.version")
+PackageNotFoundError = import_module("importlib.metadata.PackageNotFoundError")
+distributions = import_module("importlib.metadata.distributions")
 
 
 def get_sdk_details():
@@ -37,10 +41,9 @@ def get_sys_packages():
     sys_packages = {}
     for module in sys.modules:
         try:
-            version = importlib.metadata.version(module)
-            sys_packages[module] = version
-        except importlib.metadata.PackageNotFoundError:
-            # Skip built-in modules and those without package metadata
+            pkg_version = version(module)
+            sys_packages[module] = pkg_version
+        except PackageNotFoundError:
             continue
 
     return sys_packages
@@ -49,10 +52,7 @@ def get_sys_packages():
 def get_installed_packages():
     try:
         return {
-            # TODO: add to opt out
-            "Installed Packages": {
-                dist.metadata.get("Name"): dist.metadata.get("Version") for dist in importlib.metadata.distributions()
-            }
+            "Installed Packages": {dist.metadata.get("Name"): dist.metadata.get("Version") for dist in distributions()}
         }
     except:
         return {}

--- a/agentops/llms/tracker.py
+++ b/agentops/llms/tracker.py
@@ -1,6 +1,8 @@
 import sys
 from importlib import import_module
-from importlib.metadata import version
+
+# Get version from compat
+version = import_module("importlib.metadata.version")
 
 from packaging.version import Version, parse
 


### PR DESCRIPTION
Fixes #615 

- Add import_module helper function to handle version-specific imports
- Support Python <3.8 via importlib_metadata fallback
- Refactor version imports across codebase to use the helper
- Update host_env.py to use version-aware imports for package metadata

This change ensures consistent package metadata access across Python
versions while maintaining backward compatibility with Python 3.7+.
The import_module helper provides a centralized way to handle
version-specific imports, particularly for importlib.metadata vs
importlib_metadata.
