### PR TITLE
adding Docs Series YouTube video for CrewAI to the relevant docs integration page

### DIFF
--- a/docs/v1/examples/examples.mdx
+++ b/docs/v1/examples/examples.mdx
@@ -101,6 +101,46 @@ mode: "wide"
 ## Video Guides
 
 <CardGroup cols={2}>
+
+  <Card title="AgentOps x CrewAI" icon="film" iconType="solid">
+    Learn how to monitor CrewAI applications with AgentOps
+    <iframe
+      width="280"
+      height="158"
+      src="https://www.youtube.com/embed/qUSSdvp4-no"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </Card>
+
+  <Card title="AgentOps x Anthropic" icon="film" iconType="solid">
+    Learn how to monitor applications that use the Anthropic SDK directly with AgentOps
+    <iframe
+      width="280"
+      height="158"
+      src="https://www.youtube.com/embed/Yx2Crpbms7I"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </Card>
+
+  <Card title="AgentOps x OpenAI" icon="film" iconType="solid">
+    Learn how to monitor applications that use the OpenAI SDK directly with AgentOps
+    <iframe
+      width="280"
+      height="158"
+      src="https://www.youtube.com/embed/R0K9Qi2dBwM"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </Card>
+
   <Card title="Simple Agent" icon="person-carry-box" iconType="solid" href="https://www.loom.com/share/0e0d2986f3d644a58d1e186dc81cd8b1">
     Add AgentOps to a simple chat completion
     ![thumbnail](https://cdn.loom.com/sessions/thumbnails/0e0d2986f3d644a58d1e186dc81cd8b1-with-play.gif)

--- a/docs/v1/integrations/crewai.mdx
+++ b/docs/v1/integrations/crewai.mdx
@@ -6,14 +6,17 @@ description: 'AgentOps and CrewAI teamed up to make monitoring Crew agents dead 
 import CodeTooltip from '/snippets/add-code-tooltip.mdx'
 import EnvTooltip from '/snippets/add-env-tooltip.mdx'
 
-[CrewAI](https://crewai.io) is a framework for easily building multi-agent applications. Crew has comprehensive [documentation](https://docs.crewai.com) available as well as a great [quickstart](https://docs.crewai.com/how-to/Creating-a-Crew-and-kick-it-off/) guide.
+[CrewAI](https://www.crewai.com/) is a framework for easily building multi-agent applications. Crew has comprehensive [documentation](https://docs.crewai.com) available as well as a great [quickstart](https://docs.crewai.com/how-to/Creating-a-Crew-and-kick-it-off/) guide.
 
-<Card title="Crew.ai + AgentOps" icon="ship" href="https://www.loom.com/share/cfcaaef8d4a14cc7a974843bda1076bf">
-	CrewAI multi-agent framework with AgentOps support
-	![thumbnail](https://cdn.loom.com/sessions/thumbnails/cfcaaef8d4a14cc7a974843bda1076bf-1713568618224-with-play.gif)
-</Card>
-
-## Adding AgentOps to Crew agents
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/qUSSdvp4-no"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
 
 <Steps>
 	<Step title="Install the AgentOps SDK">


### PR DESCRIPTION
adding Docs Series YouTube video for CrewAI to the relevant docs integration page

## 📥 Pull Request

**📘 Description**
Here is the video being embedded on the Crew x AgentOps integration page of docs.agentops.ai:

https://www.youtube.com/watch?v=qUSSdvp4-no

**🧪 Testing**
<img width="1722" alt="Screenshot 2025-01-01 at 11 52 07 AM" src="https://github.com/user-attachments/assets/feaf989e-6264-4343-ae36-0d3d06063b81" />