### PR TITLE
Python 3.13 Compatibility & CI Improvements

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -41,8 +41,8 @@ jobs:
         continue-on-error: true
         with:
           python-version: ${{ matrix.python-version }}
-          cache-prefix: uv-${{ matrix.python-version }}
           enable-cache: true
+          cache-suffix: uv-${{ matrix.python-version }}
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -3,7 +3,7 @@
 # :: `act push -j python-tests --matrix python-version:3.10 --container-architecture linux/amd64`
 name: Python Tests
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -16,6 +16,7 @@ on:
     branches:
       - main
     paths:
+      - 'pyproject.toml'
       - 'agentops/**/*.py'
       - 'agentops/**/*.ipynb'
       - 'tests/**/*.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ dependencies = [
     "opentelemetry-api>=1.22.0,<2.0.0",
     "opentelemetry-sdk>=1.22.0,<2.0.0",
     "opentelemetry-exporter-otlp-proto-http>=1.22.0,<2.0.0",
-    # "typing-extensions>=4.9.0; python_version >= '3.8'",
-    # "pydantic>=2.7.4,<3.0.0; python_version < '3.13'",
-    # "pydantic-core>=2.23.4; python_version >= '3.8' and python_version < '3.13'"
 ]
 
 [dependency-groups]
@@ -79,6 +76,10 @@ Issues = "https://github.com/AgentOps-AI/agentops/issues"
 [tool.uv]
 compile-bytecode = true  # Enable bytecode compilation for better performance
 default-groups = ["test", "dev"]  # Default groups to install for development
+constraint-dependencies = [
+    "pydantic>=2.8.0; python_version>='3.13'",  # Ensure Python 3.13 compatibility
+    "typing-extensions; python_version>='3.13'"  # Required for Pydantic with Python 3.13
+]
 
 [tool.autopep8]
 max_line_length = 120


### PR DESCRIPTION

This PR includes two main improvements:

## 1. Python 3.13 Dependency Updates
- Ensures Pydantic ≥2.8.0 and typing-extensions are used to prevent build failures with pydantic-core when running with Python 3.13
- Implements using UV's constraint-dependencies with environment markers
- Allows flexible dependency versions for other Python versions while enforcing compatibility requirements specifically for Python 3.13

## 2. CI Workflow Enhancements
- Triggers python-tests workflow on pyproject.toml changes to ensure dependency updates are properly tested
- Updates setup-uv action configuration to use `cache-suffix` instead of deprecated `cache-prefix` parameter
- Maintains separate caches for different Python versions using `cache-suffix: uv-${python-version}`
