### PR TITLE
Fix OpenTelemetry dependency conflicts with autogen-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,12 @@ dependencies = [
     "psutil>=5.9.8,<6.1.0",
     "termcolor>=2.3.0,<2.5.0",
     "PyYAML>=5.3,<7.0",
-    "opentelemetry-api>=1.22.0,<2.0.0",
-    "opentelemetry-sdk>=1.22.0,<2.0.0",
-    "opentelemetry-exporter-otlp-proto-http>=1.22.0,<2.0.0",
+    "opentelemetry-api==1.22.0; python_version<'3.10'",
+    "opentelemetry-api>=1.27.0; python_version>='3.10'",
+    "opentelemetry-sdk==1.22.0; python_version<'3.10'",
+    "opentelemetry-sdk>=1.27.0; python_version>='3.10'",
+    "opentelemetry-exporter-otlp-proto-http==1.22.0; python_version<'3.10'",
+    "opentelemetry-exporter-otlp-proto-http>=1.27.0; python_version>='3.10'",
 ]
 
 [dependency-groups]
@@ -78,7 +81,15 @@ compile-bytecode = true  # Enable bytecode compilation for better performance
 default-groups = ["test", "dev"]  # Default groups to install for development
 constraint-dependencies = [
     "pydantic>=2.8.0; python_version>='3.13'",  # Ensure Python 3.13 compatibility
-    "typing-extensions; python_version>='3.13'"  # Required for Pydantic with Python 3.13
+    "typing-extensions; python_version>='3.13'",  # Required for Pydantic with Python 3.13
+    # For Python 3.9, use original OpenTelemetry versions
+    "opentelemetry-api==1.22.0; python_version<'3.10'",
+    "opentelemetry-sdk==1.22.0; python_version<'3.10'",
+    "opentelemetry-exporter-otlp-proto-http==1.22.0; python_version<'3.10'",
+    # For Python ≥3.10 (where autogen-core might be present), use newer versions
+    "opentelemetry-api>=1.27.0; python_version>='3.10'",
+    "opentelemetry-sdk>=1.27.0; python_version>='3.10'",
+    "opentelemetry-exporter-otlp-proto-http>=1.27.0; python_version>='3.10'"
 ]
 
 [tool.autopep8]


### PR DESCRIPTION


## Problem
Users attempting to use `agentops` alongside `autogen-core==0.4.0` encounter dependency resolution errors due to conflicting OpenTelemetry version requirements. This occurs because:
- `agentops` supports Python ≥3.9 and uses OpenTelemetry 1.22.0
- `autogen-core==0.4.0` requires Python ≥3.10 and needs OpenTelemetry ≥1.27.0

## Solution
Added version-specific OpenTelemetry constraints in `pyproject.toml` to handle both scenarios:
- For Python 3.9: Pin OpenTelemetry packages to 1.22.0 (maintaining original behavior)
- For Python ≥3.10: Allow OpenTelemetry ≥1.27.0 (compatible with autogen-core)

This ensures:
1. Python 3.9 users get our tested OpenTelemetry versions
2. Python ≥3.10 users can use `agentops` alongside `autogen-core` without conflicts

## Testing
Verified dependency resolution works in both scenarios:
- Python 3.9: Successfully installs with OpenTelemetry 1.22.0
- Python 3.10 + autogen-core: Successfully upgrades to OpenTelemetry 1.27.0

No changes to core functionality or API.