### PR TITLE
Rename InstrumentedProvider to BaseProvider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,10 +274,10 @@ We use Jupyter notebooks as integration tests for LLM providers. This approach:
 
 The `agentops/llms/` directory contains provider implementations. Each provider must:
 
-1. **Inherit from InstrumentedProvider**:
+1. **Inherit from BaseProvider**:
    ```python
    @singleton
-   class NewProvider(InstrumentedProvider):
+   class NewProvider(BaseProvider):
        def __init__(self, client):
            super().__init__(client)
            self._provider_name = "ProviderName"

--- a/agentops/llms/providers/ai21.py
+++ b/agentops/llms/providers/ai21.py
@@ -2,7 +2,7 @@ import inspect
 import pprint
 from typing import Optional
 
-from agentops.llms.providers.instrumented_provider import InstrumentedProvider
+from agentops.llms.providers.base import BaseProvider
 from agentops.time_travel import fetch_completion_override_from_time_travel_cache
 
 from agentops.event import ErrorEvent, LLMEvent, ActionEvent, ToolEvent
@@ -13,7 +13,7 @@ from agentops.singleton import singleton
 
 
 @singleton
-class AI21Provider(InstrumentedProvider):
+class AI21Provider(BaseProvider):
     original_create = None
     original_create_async = None
     original_answer = None

--- a/agentops/llms/providers/anthropic.py
+++ b/agentops/llms/providers/anthropic.py
@@ -2,7 +2,7 @@ import json
 import pprint
 from typing import Optional
 
-from agentops.llms.providers.instrumented_provider import InstrumentedProvider
+from agentops.llms.providers.base import BaseProvider
 from agentops.time_travel import fetch_completion_override_from_time_travel_cache
 
 from agentops.event import ErrorEvent, LLMEvent, ToolEvent
@@ -13,7 +13,7 @@ from agentops.singleton import singleton
 
 
 @singleton
-class AnthropicProvider(InstrumentedProvider):
+class AnthropicProvider(BaseProvider):
     original_create = None
     original_create_async = None
 

--- a/agentops/llms/providers/base.py
+++ b/agentops/llms/providers/base.py
@@ -5,7 +5,7 @@ from agentops.session import Session
 from agentops.event import LLMEvent
 
 
-class InstrumentedProvider(ABC):
+class BaseProvider(ABC):
     _provider_name: str = "InstrumentedModel"
     llm_event: Optional[LLMEvent] = None
     client = None

--- a/agentops/llms/providers/cohere.py
+++ b/agentops/llms/providers/cohere.py
@@ -2,7 +2,7 @@ import inspect
 import pprint
 from typing import Optional
 
-from .instrumented_provider import InstrumentedProvider
+from .base import BaseProvider
 from agentops.event import ActionEvent, ErrorEvent, LLMEvent
 from agentops.session import Session
 from agentops.log_config import logger
@@ -11,7 +11,7 @@ from agentops.singleton import singleton
 
 
 @singleton
-class CohereProvider(InstrumentedProvider):
+class CohereProvider(BaseProvider):
     original_create = None
     original_create_stream = None
     original_create_async = None

--- a/agentops/llms/providers/groq.py
+++ b/agentops/llms/providers/groq.py
@@ -1,7 +1,7 @@
 import pprint
 from typing import Optional
 
-from .instrumented_provider import InstrumentedProvider
+from .base import BaseProvider
 from agentops.event import ErrorEvent, LLMEvent
 from agentops.session import Session
 from agentops.log_config import logger
@@ -10,7 +10,7 @@ from agentops.singleton import singleton
 
 
 @singleton
-class GroqProvider(InstrumentedProvider):
+class GroqProvider(BaseProvider):
     original_create = None
     original_async_create = None
 

--- a/agentops/llms/providers/litellm.py
+++ b/agentops/llms/providers/litellm.py
@@ -5,13 +5,13 @@ from agentops.log_config import logger
 from agentops.event import LLMEvent, ErrorEvent
 from agentops.session import Session
 from agentops.helpers import get_ISO_time, check_call_stack_for_agent_id
-from agentops.llms.providers.instrumented_provider import InstrumentedProvider
+from agentops.llms.providers.base import BaseProvider
 from agentops.time_travel import fetch_completion_override_from_time_travel_cache
 from agentops.singleton import singleton
 
 
 @singleton
-class LiteLLMProvider(InstrumentedProvider):
+class LiteLLMProvider(BaseProvider):
     original_create = None
     original_create_async = None
     original_oai_create = None

--- a/agentops/llms/providers/llama_stack_client.py
+++ b/agentops/llms/providers/llama_stack_client.py
@@ -7,10 +7,10 @@ from agentops.event import LLMEvent, ErrorEvent, ToolEvent
 from agentops.session import Session
 from agentops.log_config import logger
 from agentops.helpers import get_ISO_time, check_call_stack_for_agent_id
-from agentops.llms.providers.instrumented_provider import InstrumentedProvider
+from agentops.llms.providers.base import BaseProvider
 
 
-class LlamaStackClientProvider(InstrumentedProvider):
+class LlamaStackClientProvider(BaseProvider):
     original_complete = None
     original_create_turn = None
 

--- a/agentops/llms/providers/mistral.py
+++ b/agentops/llms/providers/mistral.py
@@ -7,10 +7,10 @@ from agentops.event import LLMEvent, ErrorEvent
 from agentops.session import Session
 from agentops.log_config import logger
 from agentops.helpers import get_ISO_time, check_call_stack_for_agent_id
-from .instrumented_provider import InstrumentedProvider
+from .base import BaseProvider
 
 
-class MistralProvider(InstrumentedProvider):
+class MistralProvider(BaseProvider):
     original_complete = None
     original_complete_async = None
     original_stream = None

--- a/agentops/llms/providers/ollama.py
+++ b/agentops/llms/providers/ollama.py
@@ -5,14 +5,14 @@ from typing import Optional
 from agentops.event import LLMEvent
 from agentops.session import Session
 from agentops.helpers import get_ISO_time, check_call_stack_for_agent_id
-from .instrumented_provider import InstrumentedProvider
+from .base import BaseProvider
 from agentops.singleton import singleton
 
 original_func = {}
 
 
 @singleton
-class OllamaProvider(InstrumentedProvider):
+class OllamaProvider(BaseProvider):
     original_create = None
     original_create_async = None
 

--- a/agentops/llms/providers/openai.py
+++ b/agentops/llms/providers/openai.py
@@ -1,7 +1,7 @@
 import pprint
 from typing import Optional
 
-from agentops.llms.providers.instrumented_provider import InstrumentedProvider
+from agentops.llms.providers.base import BaseProvider
 from agentops.time_travel import fetch_completion_override_from_time_travel_cache
 
 from agentops.event import ActionEvent, ErrorEvent, LLMEvent
@@ -12,7 +12,7 @@ from agentops.singleton import singleton
 
 
 @singleton
-class OpenAiProvider(InstrumentedProvider):
+class OpenAiProvider(BaseProvider):
     original_create = None
     original_create_async = None
     original_assistant_methods = None

--- a/agentops/llms/providers/taskweaver.py
+++ b/agentops/llms/providers/taskweaver.py
@@ -6,12 +6,12 @@ from agentops.event import ErrorEvent, LLMEvent, ActionEvent
 from agentops.session import Session
 from agentops.log_config import logger
 from agentops.helpers import get_ISO_time, check_call_stack_for_agent_id
-from agentops.llms.providers.instrumented_provider import InstrumentedProvider
+from agentops.llms.providers.base import BaseProvider
 from agentops.singleton import singleton
 
 
 @singleton
-class TaskWeaverProvider(InstrumentedProvider):
+class TaskWeaverProvider(BaseProvider):
     original_chat_completion = None
 
     def __init__(self, client):


### PR DESCRIPTION
## Changes
- Renamed `InstrumentedProvider` class to `BaseProvider` to better reflect its role as the abstract base class for all provider implementations
- Updated all provider class imports and inheritance to use the new `BaseProvider` name
- Updated documentation in CONTRIBUTING.md to reflect the new class name

## Motivation
The name `InstrumentedProvider` was potentially misleading as it suggested the class itself handled instrumentation, when in fact it serves as an abstract base class that defines the interface and common functionality for all LLM provider implementations. The new name `BaseProvider` better communicates its role in the codebase.
