### PR TITLE
chore: add `packaging` dependency to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "psutil>=5.9.8,<6.1.0",
     "termcolor>=2.3.0,<2.5.0",
     "PyYAML>=5.3,<7.0",
+    "packaging>=21.0,<25.0", # Lower bound of 21.0 ensures compatibility with Python 3.9+
     "opentelemetry-api==1.22.0; python_version<'3.10'",
     "opentelemetry-api>=1.27.0; python_version>='3.10'",
     "opentelemetry-sdk==1.22.0; python_version<'3.10'",


### PR DESCRIPTION
While [`packaging`](https://pypi.org/project/packaging/) is a direct dependency of build tools such as `setuptools`, it is important to mention that such dependency is only installed within the build environment. 

When referenced in the codebase (`from packaging import version`), it needs to be explicitly listed dependency in pyproject.toml




