### PR TITLE
Set file logging to false by default

### DIFF
--- a/agentops/log_config.py
+++ b/agentops/log_config.py
@@ -43,7 +43,7 @@ class AgentOpsLogFileFormatter(logging.Formatter):
 
 
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
-log_to_file = os.environ.get("AGENTOPS_LOGGING_TO_FILE", "True").lower() == "true"
+log_to_file = os.environ.get("AGENTOPS_LOGGING_TO_FILE", "False").lower() == "true"
 if log_to_file:
     file_handler = logging.FileHandler("agentops.log", mode="w")
     file_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
This change updates the default behavior of the AgentOps logging configuration to not log to a file unless explicitly specified. Previously, users of other OpenSource libraries that integrate with AgentOps had to set the AGENTOPS_LOGGING_TO_FILE environment variable to avoid creating a log file by default.

With this update, the log file will not be created unless the user sets AGENTOPS_LOGGING_TO_FILE to "true". This allows users to opt-in to local file logging if they wish to see their logs locally, rather than just on the AgentOps platform.

## 📥 Pull Request

**📘 Description**
This pull request modifies the default logging behavior of the AgentOps library. The change ensures that logging to a file is disabled by default, preventing the automatic creation of a log file unless the user explicitly sets the AGENTOPS_LOGGING_TO_FILE environment variable to "true". This update is particularly beneficial for users of other OpenSource libraries that integrate with AgentOps, as it removes the need to configure environment variables to prevent unwanted log file creation.

**🧪 Testing**
1. Environment Variable Not Set:
  - Verified that no log file is created when the AGENTOPS_LOGGING_TO_FILE environment variable is not set or set to "false".
2. Environment Variable Set to True:
  - Set the AGENTOPS_LOGGING_TO_FILE environment variable to "true" and confirmed that a log file named agentops.log is created and logs are written to it.
3. Backward Compatibility:
  - Ensured that existing functionality remains unaffected for users who have already set the AGENTOPS_LOGGING_TO_FILE environment variable to "true".

