### PR TITLE
fix: LiteLLM and OpenAI SDK tracking

### DIFF
--- a/agentops/llms/tracker.py
+++ b/agentops/llms/tracker.py
@@ -154,15 +154,16 @@ class LlmTracker:
                     # Patch openai v1.0.0+ methods
                     # Ensure OpenAI is only initialized if it was NOT called inside LiteLLM
                     if not self._is_litellm_call():
-                        module_version = parse(module.__version__)
-                        if module_version >= parse("1.0.0"):
-                            provider = OpenAiProvider(self.client)
-                            provider.override()
-                        else:
-                            raise DeprecationWarning(
-                                "OpenAI versions < 0.1 are no longer supported by AgentOps. Please upgrade OpenAI or "
-                                "downgrade AgentOps to <=0.3.8."
-                            )
+                        if hasattr(module, "__version__"):
+                            module_version = parse(module.__version__)
+                            if module_version >= parse("1.0.0"):
+                                provider = OpenAiProvider(self.client)
+                                provider.override()
+                            else:
+                                raise DeprecationWarning(
+                                    "OpenAI versions < 0.1 are no longer supported by AgentOps. Please upgrade OpenAI or "
+                                    "downgrade AgentOps to <=0.3.8."
+                                )
 
                 if api == "cohere":
                     # Patch cohere v5.4.0+ methods

--- a/agentops/llms/tracker.py
+++ b/agentops/llms/tracker.py
@@ -114,11 +114,11 @@ class LlmTracker:
 
         for frame in stack:
             module = inspect.getmodule(frame.frame)
-            
+
             module_name = module.__name__ if module else None
-            
+
             filename = frame.filename.lower()
-            
+
             if module_name and "litellm" in module_name or "litellm" in filename:
                 litellm_seen = True
 
@@ -137,12 +137,12 @@ class LlmTracker:
         for api in self.SUPPORTED_APIS:
             if api in sys.modules:
                 module = import_module(api)
-                
+
                 if api == "litellm":
                     module_version = version(api)
                     if module_version is None:
                         logger.warning("Cannot determine LiteLLM version. Only LiteLLM>=1.3.1 supported.")
-                        
+
                     if Version(module_version) >= parse("1.3.1"):
                         provider = LiteLLMProvider(self.client)
                         provider.override()

--- a/agentops/llms/tracker.py
+++ b/agentops/llms/tracker.py
@@ -104,6 +104,7 @@ class LlmTracker:
         """
         Overrides key methods of the specified API to record events.
         """
+        litellm_initialized = False
 
         for api in self.SUPPORTED_APIS:
             if api in sys.modules:
@@ -116,11 +117,11 @@ class LlmTracker:
                     if Version(module_version) >= parse("1.3.1"):
                         provider = LiteLLMProvider(self.client)
                         provider.override()
+                        litellm_initialized = True
                     else:
                         logger.warning(f"Only LiteLLM>=1.3.1 supported. v{module_version} found.")
-                    return  # If using an abstraction like litellm, do not patch the underlying LLM APIs
 
-                if api == "openai":
+                if api == "openai" and not litellm_initialized:
                     # Patch openai v1.0.0+ methods
                     if hasattr(module, "__version__"):
                         module_version = parse(module.__version__)

--- a/agentops/llms/tracker.py
+++ b/agentops/llms/tracker.py
@@ -120,11 +120,9 @@ class LlmTracker:
             filename = frame.filename.lower()
             
             if module_name and "litellm" in module_name or "litellm" in filename:
-                print("LiteLLM detected.")
                 litellm_seen = True
 
             if module_name and "openai" in module_name or "openai" in filename:
-                print("OpenAI detected.")
                 openai_seen = True
 
                 if not litellm_seen:
@@ -136,8 +134,6 @@ class LlmTracker:
         """
         Overrides key methods of the specified API to record events.
         """
-        litellm_initialized = False
-        
         for api in self.SUPPORTED_APIS:
             if api in sys.modules:
                 module = import_module(api)
@@ -150,7 +146,7 @@ class LlmTracker:
                     if Version(module_version) >= parse("1.3.1"):
                         provider = LiteLLMProvider(self.client)
                         provider.override()
-                        litellm_initialized = True
+                        self.litellm_initialized = True
                     else:
                         logger.warning(f"Only LiteLLM>=1.3.1 supported. v{module_version} found.")
 


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Refactored LlmTracker to ensure proper instrumentation of OpenAI and LiteLLM calls. Now, OpenAI is only tracked when explicitly called, preventing duplicate instrumentation when used via LiteLLM. Improved call stack detection to differentiate between direct OpenAI calls and LiteLLM-wrapped calls.

**🧪 Testing**
Executed a test script covering multiple LLM providers (Anthropic, OpenAI, LiteLLM). Verified that:
✅ LiteLLM does not override OpenAI instrumentation when used explicitly.
✅ Calls to OpenAI and Anthropic through LiteLLM are correctly tracked.
✅ Direct OpenAI and Anthropic API calls function as expected.
✅ No duplicate tracking or unintended overrides occur.

EDIT (by @the-praxs): Closes #655 

