### PR TITLE
refactor: added examples and updated Haystack instrumentation to use AgentOps semconv

### DIFF
--- a/examples/haystack_examples/haystack_anthropic_example.ipynb
+++ b/examples/haystack_examples/haystack_anthropic_example.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "87626697",
+   "metadata": {},
+   "source": [
+    "First let's install the required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9599cf93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U anthropic-haystack\n",
+    "%pip install -U agentops\n",
+    "%pip install -U python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intro_anthropic",
+   "metadata": {},
+   "source": [
+    "# Anthropic-Haystack API Example with AgentOps (Philosopher Agent)\n",
+    "\n",
+    "This notebook demonstrates how to use AgentOps with Haystack's AnthropicGenerator (via the `anthropic-haystack` package) to create a Philosopher Agent. The agent leverages Anthropic's language model to answer philosophical queries with deep insight and thoughtful reasoning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports_anthropic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from haystack_integrations.components.generators.anthropic import AnthropicGenerator\n",
+    "import agentops\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Load environment variables from a .env file if available\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Load API keys from environment variables or replace with your keys\n",
+    "AGENTOPS_API_KEY = os.getenv(\"AGENTOPS_API_KEY\") or \"your_agentops_api_key\"\n",
+    "ANTHROPIC_API_KEY = os.getenv(\"ANTHROPIC_API_KEY\") or \"your_anthropic_api_key\"\n",
+    "\n",
+    "# Configure your environment for Anthropic API\n",
+    "os.environ[\"ANTHROPIC_API_KEY\"] = ANTHROPIC_API_KEY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "init_anthropic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize AgentOps with the API key\n",
+    "agentops.init(\n",
+    "    api_key=AGENTOPS_API_KEY,\n",
+    "    default_tags=['haystack', 'llm', 'Anthropic']\n",
+    ")\n",
+    "\n",
+    "# Initialize the Anthropic Generator\n",
+    "generator = AnthropicGenerator()\n",
+    "\n",
+    "# Define a Philosopher Agent that uses the AnthropicGenerator to answer philosophical queries\n",
+    "class PhilosopherAgent:\n",
+    "    def __init__(self, generator):\n",
+    "        self.generator = generator\n",
+    "\n",
+    "    def answer_question(self, question):\n",
+    "        prompt = f\"You are a thoughtful philosopher. Answer the following question with deep insight and detailed reasoning: {question}\"\n",
+    "        return self.generator.run(prompt)\n",
+    "\n",
+    "# Create an instance of the PhilosopherAgent\n",
+    "agent = PhilosopherAgent(generator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "test_anthropic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the agent to answer a philosophical question\n",
+    "response = agent.answer_question(\"What is the meaning of life?\")\n",
+    "print(\"Philosopher Agent Response:\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "end_anthropic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# End the AgentOps session\n",
+    "agentops.end_session(\"Success\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/haystack_examples/haystack_openai_example.ipynb
+++ b/examples/haystack_examples/haystack_openai_example.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "87626697",
+   "metadata": {},
+   "source": [
+    "First let's install the required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9599cf93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U haystack-ai\n",
+    "%pip install -U agentops\n",
+    "%pip install -U python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intro_openai",
+   "metadata": {},
+   "source": [
+    "# OpenAIGenerator API Example with AgentOps (Mathematician Agent)\n",
+    "\n",
+    "This notebook demonstrates how to use AgentOps with Haystack's OpenAIGenerator to create a mathematician agent. The agent leverages OpenAI's language models to solve math problems and explain its reasoning step by step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports_openai",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from haystack.components.generators import OpenAIGenerator\n",
+    "import agentops\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Load environment variables from a .env file if available\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Load API keys from environment variables or replace with your keys\n",
+    "AGENTOPS_API_KEY = os.getenv(\"AGENTOPS_API_KEY\") or \"your_agentops_api_key\"\n",
+    "OPENAI_API_KEY = os.getenv(\"OPENAI_API_KEY\") or \"your_openai_api_key\"\n",
+    "\n",
+    "# Configure your environment for OpenAI API\n",
+    "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "init_agent",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize AgentOps with the API key\n",
+    "agentops.init(\n",
+    "    api_key=AGENTOPS_API_KEY,\n",
+    "    default_tags=['haystack', 'llm', 'OpenAI']\n",
+    ")\n",
+    "\n",
+    "# Initialize the OpenAIGenerator\n",
+    "client = OpenAIGenerator(model=\"o3-mini\")\n",
+    "\n",
+    "# Define a Mathematician Agent that uses the OpenAIGenerator to solve math problems\n",
+    "class MathematicianAgent:\n",
+    "    def __init__(self, generator):\n",
+    "        self.generator = generator\n",
+    "\n",
+    "    def solve_equation(self, equation):\n",
+    "        prompt = f\"You are a mathematician. Solve the following equation and explain your reasoning step by step: {equation}\"\n",
+    "        return self.generator.run(prompt)\n",
+    "\n",
+    "# Create an instance of the MathematicianAgent\n",
+    "agent = MathematicianAgent(client)\n",
+    "\n",
+    "# Use the agent to solve a math problem\n",
+    "response = agent.solve_equation(\"2x + 3 = 7\")\n",
+    "print(\"Mathematician Agent Response:\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "end_openai",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# End the AgentOps session\n",
+    "agentops.end_session('Success')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/third_party/opentelemetry/instrumentation/haystack/utils.py
+++ b/third_party/opentelemetry/instrumentation/haystack/utils.py
@@ -6,7 +6,7 @@ import traceback
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.haystack.config import Config
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):
@@ -20,7 +20,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 
 def should_send_prompts():
     return (
-        os.getenv("TRACELOOP_TRACE_CONTENT") or "true"
+        os.getenv("AGENTOPS_TRACE_CONTENT") or "true"
     ).lower() == "true" or context_api.get_value("override_enable_content_tracing")
 
 
@@ -58,7 +58,7 @@ def process_request(span, args, kwargs):
         args_to_serialize = [arg for arg in args if not isinstance(arg, dict)]
         input_entity = {"args": args_to_serialize, "kwargs": kwargs_to_serialize}
         span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_INPUT,
+            SpanAttributes.ENTITY_INPUT,
             json.dumps(input_entity, cls=EnhancedJSONEncoder),
         )
 
@@ -67,7 +67,7 @@ def process_request(span, args, kwargs):
 def process_response(span, response):
     if should_send_prompts():
         span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+            SpanAttributes.ENTITY_OUTPUT,
             json.dumps(response, cls=EnhancedJSONEncoder),
         )
 

--- a/third_party/opentelemetry/instrumentation/haystack/wrap_node.py
+++ b/third_party/opentelemetry/instrumentation/haystack/wrap_node.py
@@ -5,7 +5,7 @@ from opentelemetry.instrumentation.utils import (
     _SUPPRESS_INSTRUMENTATION_KEY,
 )
 from opentelemetry.instrumentation.haystack.utils import with_tracer_wrapper
-from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues
+from agentops.semconv import SpanAttributes, WorkflowSpanKindValues
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ def wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
     attach(set_value("workflow_name", name))
     with tracer.start_as_current_span(f"{name}.task") as span:
         span.set_attribute(
-            SpanAttributes.TRACELOOP_SPAN_KIND,
-            TraceloopSpanKindValues.TASK.value,
+            SpanAttributes.WORKFLOW_SPAN_KIND,
+            WorkflowSpanKindValues.TASK.value,
         )
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
+        span.set_attribute(SpanAttributes.ENTITY_NAME, name)
 
         response = wrapped(*args, **kwargs)
 

--- a/third_party/opentelemetry/instrumentation/haystack/wrap_openai.py
+++ b/third_party/opentelemetry/instrumentation/haystack/wrap_openai.py
@@ -5,7 +5,7 @@ from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import Status, StatusCode
 
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
-from opentelemetry.semconv_ai import SpanAttributes, LLMRequestTypeValues
+from agentops.semconv import SpanAttributes, LLMRequestTypeValues
 from opentelemetry.instrumentation.haystack.utils import (
     dont_throw,
     with_tracer_wrapper,

--- a/third_party/opentelemetry/instrumentation/haystack/wrap_pipeline.py
+++ b/third_party/opentelemetry/instrumentation/haystack/wrap_pipeline.py
@@ -9,7 +9,7 @@ from opentelemetry.instrumentation.haystack.utils import (
     process_request,
     process_response,
 )
-from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues
+from agentops.semconv import SpanAttributes, WorkflowSpanKindValues
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +22,10 @@ def wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
     attach(set_value("workflow_name", name))
     with tracer.start_as_current_span(f"{name}.workflow") as span:
         span.set_attribute(
-            SpanAttributes.TRACELOOP_SPAN_KIND,
-            TraceloopSpanKindValues.WORKFLOW.value,
+            SpanAttributes.WORKFLOW_SPAN_KIND,
+            WorkflowSpanKindValues.WORKFLOW.value,
         )
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
+        span.set_attribute(SpanAttributes.ENTITY_NAME, name)
         process_request(span, args, kwargs)
         response = wrapped(*args, **kwargs)
         process_response(span, response)


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**

### Updated Haystack Instrumentation with Examples  
This PR enhances the Haystack instrumentation by adding examples from v0.3.26 and updating the instrumentation to use the AgentOps Semantic Convention package (`agentops.semconv`).  

#### Changes  
- Updated Haystack instrumentation to follow `agentops.semconv` conventions.
- Added example notebooks for testing the instrumentation.  

#### Testing  
- Provided notebooks for initial testing.  

#### Future Improvements  
- Add unit tests to validate instrumentation functionality.  
- Add integration tests to ensure compatibility with AgentOps.  
