### PR TITLE
Don't override endpoint URL on config init.

### DIFF
--- a/agentops/config.py
+++ b/agentops/config.py
@@ -186,8 +186,8 @@ class Config:
 
         if exporter_endpoint is not None:
             self.exporter_endpoint = exporter_endpoint
-        else:
-            self.exporter_endpoint = self.endpoint
+        # else:
+        #     self.exporter_endpoint = self.endpoint
 
     def dict(self):
         """Return a dictionary representation of the config"""


### PR DESCRIPTION
Not possible to set the endpoint via `AGENTOPS_EXPORTER_ENDPOINT` environment variable currently since it is always gets overwritten if not explicitly passed to `Config.configure`