### PR TITLE
Update Instrumentors to use semconv

### DIFF
--- a/agentops/decorators.py
+++ b/agentops/decorators.py
@@ -14,7 +14,7 @@ from opentelemetry.trace import Span, SpanKind as OTelSpanKind
 import agentops
 from agentops.session.state import SessionState
 from agentops.semconv import (
-    SpanKind, 
+    AgentOpsSpanKindValues, 
     AgentAttributes, 
     ToolAttributes, 
     CoreAttributes,
@@ -139,7 +139,7 @@ def agent(
             span_attributes[AgentAttributes.AGENT_ID] = agent_id
             
             # Add span kind directly to attributes
-            span_attributes["span.kind"] = SpanKind.AGENT
+            span_attributes["span.kind"] = AgentOpsSpanKindValues.AGENT.value
             
             # Create and start the span as a child of the current span (session)
             # Store the context manager and use it to access the span
@@ -247,7 +247,7 @@ def tool(
             span_attributes.update(kwargs)
             
             # Add span kind directly to attributes
-            span_attributes["span.kind"] = SpanKind.TOOL
+            span_attributes["span.kind"] = AgentOpsSpanKindValues.TOOL.value
             
             # Create and start the span as a child of the current span
             with _tracer.start_as_current_span(
@@ -257,7 +257,7 @@ def tool(
             ) as span:
                 try:
                     # Set initial status
-                    span.set_attribute(ToolAttributes.TOOL_STATUS, ToolStatus.EXECUTING)
+                    span.set_attribute(ToolAttributes.TOOL_STATUS, ToolStatus.EXECUTING.value)
                     
                     # Call the original function
                     result = func(*args, **kwargs)
@@ -272,12 +272,12 @@ def tool(
                             span.set_attribute(ToolAttributes.TOOL_RESULT, f"<{type(result).__name__}>")
                     
                     # Set success status
-                    span.set_attribute(ToolAttributes.TOOL_STATUS, ToolStatus.SUCCEEDED)
+                    span.set_attribute(ToolAttributes.TOOL_STATUS, ToolStatus.SUCCEEDED.value)
                     
                     return result
                 except Exception as e:
                     # Set error status and attributes
-                    span.set_attribute(ToolAttributes.TOOL_STATUS, ToolStatus.FAILED)
+                    span.set_attribute(ToolAttributes.TOOL_STATUS, ToolStatus.FAILED.value)
                     span.set_attribute(CoreAttributes.ERROR_TYPE, type(e).__name__)
                     span.set_attribute(CoreAttributes.ERROR_MESSAGE, str(e))
                     

--- a/agentops/semconv/__init__.py
+++ b/agentops/semconv/__init__.py
@@ -5,11 +5,26 @@ from .core import CoreAttributes
 from .agent import AgentAttributes
 from .tool import ToolAttributes
 from .status import ToolStatus
-
+from .workflow import WorkflowAttributes
+from .instrumentation import InstrumentationAttributes
+from .llm import LLMAttributes
+from .enum import LLMRequestTypeValues
+from .span_attributes import SpanAttributes
+from .meters import Meters
+from .span_kinds import AgentOpsSpanKindValues
+SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY = "suppress_language_model_instrumentation"
 __all__ = [
+    "SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY",
     "SpanKind",
     "CoreAttributes",
     "AgentAttributes",
     "ToolAttributes",
     "ToolStatus",
+    "WorkflowAttributes",
+    "InstrumentationAttributes",
+    "LLMAttributes",
+    "LLMRequestTypeValues",
+    "SpanAttributes",
+    "Meters",
+    "AgentOpsSpanKindValues"
 ]

--- a/agentops/semconv/enum.py
+++ b/agentops/semconv/enum.py
@@ -1,0 +1,9 @@
+"""Enum for LLM request types."""
+from enum import Enum
+
+class LLMRequestTypeValues(Enum):
+    COMPLETION = "completion"
+    CHAT = "chat"
+    RERANK = "rerank"
+    EMBEDDING = "embedding"
+    UNKNOWN = "unknown"

--- a/agentops/semconv/instrumentation.py
+++ b/agentops/semconv/instrumentation.py
@@ -1,0 +1,6 @@
+"""Attributes specific to instrumentation."""
+class InstrumentationAttributes:
+    """Instrumentation specific attributes."""
+    
+    NAME = "instrumentation.name"          # Name of the instrumentation
+    VERSION = "instrumentation.version"    # Version of the instrumentation

--- a/agentops/semconv/llm.py
+++ b/agentops/semconv/llm.py
@@ -1,0 +1,33 @@
+"""Attributes specific to LLM spans."""
+
+class LLMAttributes:
+    """Attributes specific to LLM spans."""
+    
+    # Identity
+    MODEL_NAME = "llm.model.name"          # Name of the LLM model
+    
+    # Usage metrics
+    INPUT_TOKENS = "llm.usage.input_tokens"    # Number of input tokens
+    OUTPUT_TOKENS = "llm.usage.output_tokens"  # Number of output tokens
+    TOTAL_TOKENS = "llm.usage.total_tokens"    # Total number of tokens
+    
+    # Content
+    PROMPT = "llm.prompt"                  # Prompt sent to the LLM
+    COMPLETION = "llm.completion"          # Completion returned by the LLM
+    
+    # Request parameters
+    TEMPERATURE = "llm.request.temperature"        # Temperature parameter
+    TOP_P = "llm.request.top_p"                    # Top-p parameter
+    MAX_TOKENS = "llm.request.max_tokens"          # Maximum tokens to generate
+    FREQUENCY_PENALTY = "llm.request.frequency_penalty"  # Frequency penalty
+    PRESENCE_PENALTY = "llm.request.presence_penalty"    # Presence penalty
+    
+    # Request metadata
+    REQUEST_TYPE = "llm.request.type"              # Type of request (chat, completion, etc.)
+    IS_STREAMING = "llm.request.is_streaming"      # Whether the request is streaming
+    
+    # Response metadata
+    FINISH_REASON = "llm.response.finish_reason"   # Reason for finishing generation
+    
+    # System
+    SYSTEM = "llm.system"                  # System message or context 

--- a/agentops/semconv/meters.py
+++ b/agentops/semconv/meters.py
@@ -1,0 +1,17 @@
+"""Metrics for OpenTelemetry semantic conventions."""
+
+class Meters:
+    LLM_GENERATION_CHOICES = "gen_ai.client.generation.choices"
+    LLM_TOKEN_USAGE = "gen_ai.client.token.usage"
+    LLM_OPERATION_DURATION = "gen_ai.client.operation.duration"
+    LLM_COMPLETIONS_EXCEPTIONS = "llm.openai.chat_completions.exceptions"
+    LLM_STREAMING_TIME_TO_FIRST_TOKEN = (
+        "llm.openai.chat_completions.streaming_time_to_first_token"
+    )
+    LLM_STREAMING_TIME_TO_GENERATE = (
+        "llm.openai.chat_completions.streaming_time_to_generate"
+    )
+    LLM_EMBEDDINGS_EXCEPTIONS = "llm.openai.embeddings.exceptions"
+    LLM_EMBEDDINGS_VECTOR_SIZE = "llm.openai.embeddings.vector_size"
+    LLM_IMAGE_GENERATIONS_EXCEPTIONS = "llm.openai.image_generations.exceptions"
+    LLM_ANTHROPIC_COMPLETION_EXCEPTIONS = "llm.anthropic.completion.exceptions"

--- a/agentops/semconv/span_attributes.py
+++ b/agentops/semconv/span_attributes.py
@@ -1,0 +1,53 @@
+"""Span attributes for OpenTelemetry semantic conventions."""
+
+class SpanAttributes:
+    # Semantic Conventions for LLM requests, this needs to be removed after
+    # OpenTelemetry Semantic Conventions support Gen AI.
+    # Issue at https://github.com/open-telemetry/opentelemetry-python/issues/3868
+    # Refer to https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md
+    # for more detail for LLM spans from OpenTelemetry Community.
+    LLM_SYSTEM = "gen_ai.system"
+    LLM_REQUEST_MODEL = "gen_ai.request.model"
+    LLM_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
+    LLM_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
+    LLM_REQUEST_TOP_P = "gen_ai.request.top_p"
+    LLM_PROMPTS = "gen_ai.prompt"
+    LLM_COMPLETIONS = "gen_ai.completion"
+    LLM_RESPONSE_MODEL = "gen_ai.response.model"
+    LLM_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
+    LLM_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
+    LLM_USAGE_CACHE_CREATION_INPUT_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
+    LLM_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read_input_tokens"
+    LLM_TOKEN_TYPE = "gen_ai.token.type"
+    # To be added
+    # LLM_RESPONSE_ID = "gen_ai.response.id"
+
+    # LLM
+    LLM_REQUEST_TYPE = "llm.request.type"
+    LLM_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens"
+    LLM_USAGE_TOKEN_TYPE = "llm.usage.token_type"
+    LLM_USER = "llm.user"
+    LLM_HEADERS = "llm.headers"
+    LLM_IS_STREAMING = "llm.is_streaming"
+    LLM_FREQUENCY_PENALTY = "llm.frequency_penalty"
+    LLM_PRESENCE_PENALTY = "llm.presence_penalty"
+    LLM_REQUEST_FUNCTIONS = "llm.request.functions"
+    LLM_RESPONSE_FINISH_REASON = "llm.response.finish_reason"
+    LLM_RESPONSE_STOP_REASON = "llm.response.stop_reason"
+    LLM_CONTENT_COMPLETION_CHUNK = "llm.content.completion.chunk"
+
+    # OpenAI
+    LLM_OPENAI_RESPONSE_SYSTEM_FINGERPRINT = "gen_ai.openai.system_fingerprint"
+    LLM_OPENAI_API_BASE = "gen_ai.openai.api_base"
+    LLM_OPENAI_API_VERSION = "gen_ai.openai.api_version"
+    LLM_OPENAI_API_TYPE = "gen_ai.openai.api_type"
+    
+    
+    AGENTOPS_ENTITY_OUTPUT = "agentops.entity.output"
+    AGENTOPS_ENTITY_INPUT = "agentops.entity.input"
+    AGENTOPS_SPAN_KIND = "agentops.span.kind"
+    AGENTOPS_ENTITY_NAME = "agentops.entity.name"
+    
+    # Haystack
+    HAYSTACK_OPENAI_CHAT = "haystack.openai.chat"
+    HAYSTACK_OPENAI_COMPLETION = "haystack.openai.completion"

--- a/agentops/semconv/span_kinds.py
+++ b/agentops/semconv/span_kinds.py
@@ -1,12 +1,7 @@
-"""Defines the kinds of spans in AgentOps."""
-
+"""Span kinds for AgentOps."""
+from enum import Enum
 class SpanKind:
     """Defines the kinds of spans in AgentOps."""
-    
-    # Core span kinds
-    AGENT = "agent"                    # Agent instance
-    TOOL = "tool"                      # Tool execution
-    
     # Agent action kinds
     AGENT_ACTION = "agent.action"      # Agent performing an action
     AGENT_THINKING = "agent.thinking"  # Agent reasoning/planning
@@ -18,4 +13,11 @@ class SpanKind:
     
     # Workflow kinds
     WORKFLOW_STEP = "workflow.step"    # Step in a workflow
-    WORKFLOW_TASK = "workflow.task"    # Task in a workflow
+    
+
+class AgentOpsSpanKindValues(Enum):
+    WORKFLOW = "workflow"
+    TASK = "task"
+    AGENT = "agent"
+    TOOL = "tool"
+    UNKNOWN = "unknown"

--- a/agentops/semconv/status.py
+++ b/agentops/semconv/status.py
@@ -1,6 +1,6 @@
 """Status enumerations for spans."""
-
-class ToolStatus:
+from enum import Enum
+class ToolStatus(Enum):
     """Tool status values."""
     
     EXECUTING = "executing"

--- a/agentops/semconv/workflow.py
+++ b/agentops/semconv/workflow.py
@@ -1,0 +1,11 @@
+"""Attributes specific to workflow spans."""
+
+class WorkflowAttributes:
+    """Workflow specific attributes."""
+    
+    WORKFLOW_NAME = "workflow.name"        # Name of the workflow
+    WORKFLOW_TYPE = "workflow.type"        # Type of workflow
+    WORKFLOW_INPUT = "workflow.input"      # Input to the workflow
+    WORKFLOW_OUTPUT = "workflow.output"    # Output from the workflow
+    MAX_TURNS = "workflow.max_turns"       # Maximum number of turns in a workflow
+    FINAL_OUTPUT = "workflow.final_output" # Final output of the workflow

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -9,7 +9,7 @@ from opentelemetry.trace import Span, NonRecordingSpan, SpanContext
 
 import agentops
 from agentops.decorators import agent, tool, span, create_span, current_span, add_span_attribute
-from agentops.semconv import SpanKind, AgentAttributes, ToolAttributes, CoreAttributes, ToolStatus
+from agentops.semconv import SpanKind, AgentAttributes, ToolAttributes, CoreAttributes, ToolStatus, AgentOpsSpanKindValues
 
 from agentops.decorators import session
 from agentops.session.session import SessionState
@@ -139,7 +139,7 @@ def test_agent_decorator_basic():
         assert call_args["name"] == "test_agent"
         assert "attributes" in call_args
         attributes = call_args["attributes"]
-        assert attributes.get("span.kind") == SpanKind.AGENT
+        assert attributes.get("span.kind") == AgentOpsSpanKindValues.AGENT.value
         assert attributes.get(AgentAttributes.AGENT_ROLE) == "test_role"
         
         # Check that the original functionality works
@@ -391,7 +391,7 @@ async def test_span_decorator_async():
         mock_start_span.return_value.__enter__.return_value = mock_span
         mock_tracer.start_as_current_span = mock_start_span
 
-        @span(name="async_span", kind=SpanKind.AGENT_ACTION)
+        @span(name="async_span", kind=AgentOpsSpanKindValues.AGENT.value)
         async def async_function(a, b):
             await asyncio.sleep(0.01)  # Small delay
             return a + b
@@ -408,7 +408,7 @@ async def test_span_decorator_async():
         assert call_args["name"] == "async_span"
         assert "attributes" in call_args
         attributes = call_args["attributes"]
-        assert attributes.get("span.kind") == SpanKind.AGENT_ACTION
+        assert attributes.get("span.kind") == AgentOpsSpanKindValues.AGENT.value
 
 
 def test_span_decorator_method():

--- a/third_party/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/third_party/opentelemetry/instrumentation/anthropic/__init__.py
@@ -29,7 +29,7 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY, unwrap
 from opentelemetry.metrics import Counter, Histogram, Meter, get_meter
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_RESPONSE_ID
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     LLMRequestTypeValues,
     SpanAttributes,

--- a/third_party/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/third_party/opentelemetry/instrumentation/anthropic/streaming.py
@@ -12,7 +12,7 @@ from opentelemetry.instrumentation.anthropic.utils import (
 )
 from opentelemetry.metrics import Counter, Histogram
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_RESPONSE_ID
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
 
 logger = logging.getLogger(__name__)

--- a/third_party/opentelemetry/instrumentation/anthropic/utils.py
+++ b/third_party/opentelemetry/instrumentation/anthropic/utils.py
@@ -5,7 +5,7 @@ import threading
 import traceback
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.anthropic.config import Config
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 
 GEN_AI_SYSTEM = "gen_ai.system"
 GEN_AI_SYSTEM_ANTHROPIC = "anthropic"

--- a/third_party/opentelemetry/instrumentation/cohere/__init__.py
+++ b/third_party/opentelemetry/instrumentation/cohere/__init__.py
@@ -18,7 +18,7 @@ from opentelemetry.instrumentation.utils import (
 )
 
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_RESPONSE_ID
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     SpanAttributes,
     LLMRequestTypeValues,

--- a/third_party/opentelemetry/instrumentation/crewai/instrumentation.py
+++ b/third_party/opentelemetry/instrumentation/crewai/instrumentation.py
@@ -9,7 +9,7 @@ from opentelemetry.metrics import Histogram, Meter, get_meter
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.crewai.version import __version__
-from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues, Meters
+from agentops.semconv import SpanAttributes, AgentOpsSpanKindValues, Meters
 from .crewai_span_attributes import CrewAISpanAttributes, set_span_attribute
 
 _instruments = ("crewai >= 0.70.0",)
@@ -98,7 +98,7 @@ def wrap_agent_execute_task(tracer, duration_histogram, token_histogram, wrapped
         f"{agent_name}.agent",
         kind=SpanKind.CLIENT,
         attributes={
-            SpanAttributes.TRACELOOP_SPAN_KIND: TraceloopSpanKindValues.AGENT.value,
+            SpanAttributes.AGENTOPS_SPAN_KIND: AgentOpsSpanKindValues.AGENT.value,
         }
     ) as span:
         try:
@@ -139,13 +139,13 @@ def wrap_task_execute(tracer, duration_histogram, token_histogram, wrapped, inst
         f"{task_name}.task",
         kind=SpanKind.CLIENT,
         attributes={
-            SpanAttributes.TRACELOOP_SPAN_KIND: TraceloopSpanKindValues.TASK.value,
+            SpanAttributes.AGENTOPS_SPAN_KIND: AgentOpsSpanKindValues.TASK.value,
         }
     ) as span:
         try:
             CrewAISpanAttributes(span=span, instance=instance)
             result = wrapped(*args, **kwargs)
-            set_span_attribute(span, SpanAttributes.TRACELOOP_ENTITY_OUTPUT, str(result))
+            set_span_attribute(span, SpanAttributes.AGENTOPS_ENTITY_OUTPUT, str(result))
             span.set_status(Status(StatusCode.OK))
             return result
         except Exception as ex:
@@ -185,7 +185,7 @@ def wrap_llm_call(tracer, duration_histogram, token_histogram, wrapped, instance
 
 
 def is_metrics_enabled() -> bool:
-    return (os.getenv("TRACELOOP_METRICS_ENABLED") or "true").lower() == "true"
+    return (os.getenv("AGENTOPS_METRICS_ENABLED") or "true").lower() == "true"
 
 
 def _create_metrics(meter: Meter):

--- a/third_party/opentelemetry/instrumentation/groq/__init__.py
+++ b/third_party/opentelemetry/instrumentation/groq/__init__.py
@@ -24,7 +24,7 @@ from opentelemetry.metrics import Counter, Histogram, Meter, get_meter
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_RESPONSE_ID,
 )
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     LLMRequestTypeValues,
     SpanAttributes,

--- a/third_party/opentelemetry/instrumentation/groq/utils.py
+++ b/third_party/opentelemetry/instrumentation/groq/utils.py
@@ -4,7 +4,7 @@ import logging
 import traceback
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.groq.config import Config
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 
 GEN_AI_SYSTEM = "gen_ai.system"
 GEN_AI_SYSTEM_GROQ = "groq"

--- a/third_party/opentelemetry/instrumentation/haystack/utils.py
+++ b/third_party/opentelemetry/instrumentation/haystack/utils.py
@@ -6,7 +6,7 @@ import traceback
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.haystack.config import Config
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):
@@ -58,7 +58,7 @@ def process_request(span, args, kwargs):
         args_to_serialize = [arg for arg in args if not isinstance(arg, dict)]
         input_entity = {"args": args_to_serialize, "kwargs": kwargs_to_serialize}
         span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_INPUT,
+            SpanAttributes.AGENTOPS_ENTITY_INPUT,
             json.dumps(input_entity, cls=EnhancedJSONEncoder),
         )
 
@@ -67,7 +67,7 @@ def process_request(span, args, kwargs):
 def process_response(span, response):
     if should_send_prompts():
         span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+            SpanAttributes.AGENTOPS_ENTITY_OUTPUT,
             json.dumps(response, cls=EnhancedJSONEncoder),
         )
 

--- a/third_party/opentelemetry/instrumentation/haystack/wrap_node.py
+++ b/third_party/opentelemetry/instrumentation/haystack/wrap_node.py
@@ -5,7 +5,7 @@ from opentelemetry.instrumentation.utils import (
     _SUPPRESS_INSTRUMENTATION_KEY,
 )
 from opentelemetry.instrumentation.haystack.utils import with_tracer_wrapper
-from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues
+from agentops.semconv import SpanAttributes, AgentOpsSpanKindValues
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ def wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
     attach(set_value("workflow_name", name))
     with tracer.start_as_current_span(f"{name}.task") as span:
         span.set_attribute(
-            SpanAttributes.TRACELOOP_SPAN_KIND,
-            TraceloopSpanKindValues.TASK.value,
+            SpanAttributes.AGENTOPS_SPAN_KIND,
+            AgentOpsSpanKindValues.TASK.value,
         )
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
+        span.set_attribute(SpanAttributes.AGENTOPS_ENTITY_NAME, name)
 
         response = wrapped(*args, **kwargs)
 

--- a/third_party/opentelemetry/instrumentation/haystack/wrap_openai.py
+++ b/third_party/opentelemetry/instrumentation/haystack/wrap_openai.py
@@ -5,7 +5,7 @@ from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import Status, StatusCode
 
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
-from opentelemetry.semconv_ai import SpanAttributes, LLMRequestTypeValues
+from agentops.semconv import SpanAttributes, LLMRequestTypeValues
 from opentelemetry.instrumentation.haystack.utils import (
     dont_throw,
     with_tracer_wrapper,

--- a/third_party/opentelemetry/instrumentation/haystack/wrap_pipeline.py
+++ b/third_party/opentelemetry/instrumentation/haystack/wrap_pipeline.py
@@ -9,7 +9,7 @@ from opentelemetry.instrumentation.haystack.utils import (
     process_request,
     process_response,
 )
-from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues
+from agentops.semconv import SpanAttributes, AgentOpsSpanKindValues
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +22,10 @@ def wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
     attach(set_value("workflow_name", name))
     with tracer.start_as_current_span(f"{name}.workflow") as span:
         span.set_attribute(
-            SpanAttributes.TRACELOOP_SPAN_KIND,
-            TraceloopSpanKindValues.WORKFLOW.value,
+            SpanAttributes.AGENTOPS_SPAN_KIND,
+            AgentOpsSpanKindValues.WORKFLOW.value,
         )
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
+        span.set_attribute(SpanAttributes.AGENTOPS_ENTITY_NAME, name)
         process_request(span, args, kwargs)
         response = wrapped(*args, **kwargs)
         process_response(span, response)

--- a/third_party/opentelemetry/instrumentation/mistralai/__init__.py
+++ b/third_party/opentelemetry/instrumentation/mistralai/__init__.py
@@ -19,7 +19,7 @@ from opentelemetry.instrumentation.utils import (
 )
 
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_RESPONSE_ID
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     SpanAttributes,
     LLMRequestTypeValues,

--- a/third_party/opentelemetry/instrumentation/ollama/__init__.py
+++ b/third_party/opentelemetry/instrumentation/ollama/__init__.py
@@ -18,7 +18,7 @@ from opentelemetry.instrumentation.utils import (
     unwrap,
 )
 
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     SpanAttributes,
     LLMRequestTypeValues,

--- a/third_party/opentelemetry/instrumentation/openai/shared/__init__.py
+++ b/third_party/opentelemetry/instrumentation/openai/shared/__init__.py
@@ -14,7 +14,7 @@ from opentelemetry.instrumentation.openai.shared.config import Config
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_RESPONSE_ID,
 )
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 from opentelemetry.instrumentation.openai.utils import (
     dont_throw,
     is_openai_v1,

--- a/third_party/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
+++ b/third_party/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
@@ -8,7 +8,7 @@ from wrapt import ObjectProxy
 
 from opentelemetry import context as context_api
 from opentelemetry.metrics import Counter, Histogram
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     SpanAttributes,
     LLMRequestTypeValues,

--- a/third_party/opentelemetry/instrumentation/openai/shared/completion_wrappers.py
+++ b/third_party/opentelemetry/instrumentation/openai/shared/completion_wrappers.py
@@ -2,7 +2,7 @@ import logging
 
 from opentelemetry import context as context_api
 
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     SpanAttributes,
     LLMRequestTypeValues,

--- a/third_party/opentelemetry/instrumentation/openai/shared/embeddings_wrappers.py
+++ b/third_party/opentelemetry/instrumentation/openai/shared/embeddings_wrappers.py
@@ -3,7 +3,7 @@ import time
 
 from opentelemetry import context as context_api
 from opentelemetry.metrics import Counter, Histogram
-from opentelemetry.semconv_ai import (
+from agentops.semconv import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     SpanAttributes,
     LLMRequestTypeValues,

--- a/third_party/opentelemetry/instrumentation/openai/shared/image_gen_wrappers.py
+++ b/third_party/opentelemetry/instrumentation/openai/shared/image_gen_wrappers.py
@@ -12,7 +12,7 @@ from opentelemetry.instrumentation.openai.utils import (
 )
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.metrics import Counter, Histogram
-from opentelemetry.semconv_ai import SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY
+from agentops.semconv import SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY
 
 
 @_with_image_gen_metric_wrapper

--- a/third_party/opentelemetry/instrumentation/openai/v0/__init__.py
+++ b/third_party/opentelemetry/instrumentation/openai/v0/__init__.py
@@ -19,7 +19,7 @@ from opentelemetry.instrumentation.openai.shared.embeddings_wrappers import (
 )
 from opentelemetry.instrumentation.openai.utils import is_metrics_enabled
 from opentelemetry.instrumentation.openai.version import __version__
-from opentelemetry.semconv_ai import Meters
+from agentops.semconv import Meters
 
 _instruments = ("openai >= 0.27.0", "openai < 1.0.0")
 

--- a/third_party/opentelemetry/instrumentation/openai/v1/__init__.py
+++ b/third_party/opentelemetry/instrumentation/openai/v1/__init__.py
@@ -33,7 +33,7 @@ from opentelemetry.instrumentation.openai.v1.assistant_wrappers import (
 from opentelemetry.instrumentation.openai.utils import is_metrics_enabled
 from opentelemetry.instrumentation.openai.version import __version__
 
-from opentelemetry.semconv_ai import Meters
+from agentops.semconv import Meters
 
 _instruments = ("openai >= 1.0.0",)
 

--- a/third_party/opentelemetry/instrumentation/openai/v1/assistant_wrappers.py
+++ b/third_party/opentelemetry/instrumentation/openai/v1/assistant_wrappers.py
@@ -8,7 +8,7 @@ from opentelemetry.instrumentation.openai.shared import (
 from opentelemetry.trace import SpanKind
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 
-from opentelemetry.semconv_ai import SpanAttributes, LLMRequestTypeValues
+from agentops.semconv import SpanAttributes, LLMRequestTypeValues
 
 from opentelemetry.instrumentation.openai.utils import _with_tracer_wrapper, dont_throw
 from opentelemetry.instrumentation.openai.shared.config import Config

--- a/third_party/opentelemetry/instrumentation/openai/v1/event_handler_wrapper.py
+++ b/third_party/opentelemetry/instrumentation/openai/v1/event_handler_wrapper.py
@@ -1,7 +1,7 @@
 from opentelemetry.instrumentation.openai.shared import (
     _set_span_attribute,
 )
-from opentelemetry.semconv_ai import SpanAttributes
+from agentops.semconv import SpanAttributes
 from openai import AssistantEventHandler
 from typing_extensions import override
 


### PR DESCRIPTION
## 📥 Pull Request

Closes #784 
**📘 Description**

**Overview:**  
This PR introduces the `semconv` module, which sets up our own rules for labeling data from instrumentors. By keeping this module in the Agentops namespace, we ensure that everyone using Agentops can easily adopt our conventions.

**Mission Statement:**  
Our goal is to create a clear and simple system for labeling data. The `semconv` module will help make data processing more efficient and reduce errors by providing a consistent framework for all instrumentors.

**Key Changes:**  
- **Define Semantic Keys:** The module sets up a clear set of keys and values to label data consistently.  
- **Ensure Consistency:** It enforces uniform data labeling across all instrumentors, making integration with internal tools smoother.  
- **Support for Internal and External Use:** Although designed for internal use, the module is built into Agentops so that any user can benefit from our conventions.  
- **Easy Expansion:** The design allows for future additions or modifications without breaking existing functionality.

**How to Use:**  
- **Internal Tools:** The module will be integrated with our internal data processing tools to ensure smooth and consistent data handling.  
- **Agentops SDK Users:** Anyone using Agentops will have access to these conventions, promoting uniformity across different projects.

**References:**  
- This design draws inspiration from the approaches used in the [openlit](https://github.com/openlit/openlit) and [openllmetery](https://github.com/traceloop/openllmetry) repositories.