### PR TITLE
Remove dotenv, version bump.

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -1,13 +1,9 @@
 from typing import Dict, List, Optional, Union, Any
 
-from dotenv import load_dotenv
-
 from .client import Client
 from .sdk.commands import record as sdk_record, start_span as sdk_start_span, end_span as sdk_end_span
 from .semconv.span_kinds import SpanKind
 import agentops.legacy as legacy
-
-load_dotenv()
 
 # Client global instance; one per process runtime
 _client = Client()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentops"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },


### PR DESCRIPTION
At some point `dotenv` got added to `__init__.py` but not as a dependency. We don't need to init the env, that's up to the user. 