### PR TITLE
Add system stats and imported libraries tracking

### DIFF
--- a/agentops/sdk/core.py
+++ b/agentops/sdk/core.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import atexit
 import threading
+import platform
+import sys
+import os
+import psutil
 from typing import List, Optional
 
 from opentelemetry import metrics, trace
@@ -22,6 +26,73 @@ from agentops.sdk.types import TracingConfig
 from agentops.semconv import ResourceAttributes
 
 # No need to create shortcuts since we're using our own ResourceAttributes class now
+
+
+def get_imported_libraries():
+    """
+    Get the top-level imported libraries in the current script.
+    
+    Returns:
+        list: List of imported libraries
+    """
+    user_libs = []
+    
+    builtin_modules = {
+        'builtins', 'sys', 'os', '_thread', 'abc', 'io', 're', 'types', 
+        'collections', 'enum', 'math', 'datetime', 'time', 'warnings'
+    }
+    
+    try:
+        main_module = sys.modules.get('__main__')
+        if main_module and hasattr(main_module, '__dict__'):
+            for name, obj in main_module.__dict__.items():
+                if isinstance(obj, type(sys)) and hasattr(obj, '__name__'):
+                    mod_name = obj.__name__.split('.')[0]
+                    if (mod_name and 
+                        not mod_name.startswith('_') and
+                        mod_name not in builtin_modules):
+                        user_libs.append(mod_name)
+    except Exception as e:
+        logger.debug(f"Error getting imports: {e}")
+    
+    return user_libs
+
+
+def get_system_stats():
+    """
+    Get basic system stats including CPU and memory information.
+    
+    Returns:
+        dict: Dictionary with system information
+    """
+    system_info = {
+        ResourceAttributes.HOST_MACHINE: platform.machine(),
+        ResourceAttributes.HOST_NAME: platform.node(),
+        ResourceAttributes.HOST_NODE: platform.node(),
+        ResourceAttributes.HOST_PROCESSOR: platform.processor(),
+        ResourceAttributes.HOST_SYSTEM: platform.system(),
+        ResourceAttributes.HOST_VERSION: platform.version(),
+        ResourceAttributes.HOST_OS_RELEASE: platform.release(),
+    }
+    
+    # Add CPU stats
+    try:
+        system_info[ResourceAttributes.CPU_COUNT] = os.cpu_count() or 0
+        system_info[ResourceAttributes.CPU_PERCENT] = psutil.cpu_percent(interval=0.1)
+    except Exception as e:
+        logger.debug(f"Error getting CPU stats: {e}")
+    
+    # Add memory stats
+    try:
+        memory = psutil.virtual_memory()
+        system_info[ResourceAttributes.MEMORY_TOTAL] = memory.total
+        system_info[ResourceAttributes.MEMORY_AVAILABLE] = memory.available
+        system_info[ResourceAttributes.MEMORY_USED] = memory.used
+        system_info[ResourceAttributes.MEMORY_PERCENT] = memory.percent
+    except Exception as e:
+        logger.debug(f"Error getting memory stats: {e}")
+    
+    return system_info
 
 
 def setup_telemetry(
@@ -58,6 +129,14 @@ def setup_telemetry(
         # Add project_id as a custom resource attribute
         resource_attrs[ResourceAttributes.PROJECT_ID] = project_id
         logger.debug(f"Including project_id in resource attributes: {project_id}")
+    
+    # Add system information
+    system_stats = get_system_stats()
+    resource_attrs.update(system_stats)
+    
+    # Add imported libraries
+    imported_libraries = get_imported_libraries()
+    resource_attrs[ResourceAttributes.IMPORTED_LIBRARIES] = imported_libraries
 
     resource = Resource(resource_attrs)
     provider = TracerProvider(resource=resource)

--- a/agentops/semconv/resource.py
+++ b/agentops/semconv/resource.py
@@ -28,3 +28,25 @@ class ResourceAttributes:
     # SDK attributes
     SDK_NAME = "agentops.sdk.name"
     SDK_VERSION = "agentops.sdk.version"
+
+    # Host machine attributes
+    HOST_MACHINE = "host.machine"
+    HOST_NAME = "host.name"
+    HOST_NODE = "host.node"
+    HOST_OS_RELEASE = "host.os_release"
+    HOST_PROCESSOR = "host.processor"
+    HOST_SYSTEM = "host.system"
+    HOST_VERSION = "host.version"
+    
+    # CPU attributes
+    CPU_COUNT = "cpu.count"
+    CPU_PERCENT = "cpu.percent"
+    
+    # Memory attributes
+    MEMORY_TOTAL = "memory.total"
+    MEMORY_AVAILABLE = "memory.available"
+    MEMORY_USED = "memory.used"
+    MEMORY_PERCENT = "memory.percent"
+    
+    # Libraries
+    IMPORTED_LIBRARIES = "imported_libraries"


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Closes #913 
Add system stats and imported libraries tracking

- Introduced `get_system_stats` function to collect CPU and memory information.
- Added `get_imported_libraries` function to retrieve top-level imported libraries.
- Updated `setup_telemetry` to include system stats and imported libraries in resource attributes.
- Expanded `ResourceAttributes` class to define new attributes for system and library information.

Note: `"os.type": "linux"` is default behaviour of OTEL.

**🧪 Testing**
```
  "resource_attributes": {
    "ProjectId": "6952a1d4-8a47-4c8b-98c5-1d03813ae5ad",
    "agentops.project.id": "6952a1d4-8a47-4c8b-98c5-1d03813ae5ad",
    "cpu.count": "16",
    "cpu.percent": "11",
    "host.machine": "AMD64",
    "host.name": "fd7ce180eb77",
    "host.node": "DESKTOP-ADFQBKV",
    "host.os_release": "10",
    "host.processor": "Intel64 Family 6 Model 154 Stepping 3, GenuineIntel",
    "host.system": "Windows",
    "host.version": "10.0.26100",
    "imported_libraries": "[\"agentops\",\"anthropic\",\"haystack\",\"litellm\",\"agents\",\"opentelemetry\"]",
    "memory.available": "3540471808",
    "memory.percent": "79",
    "memory.total": "16849293312",
    "memory.used": "13308821504",
    "os.type": "linux",
    "service.name": "agentops"
  },
```