### PR TITLE
Added the stream to handle the streaming responses

### DIFF
--- a/tests/unit/instrumentation/anthropic/test_attributes.py
+++ b/tests/unit/instrumentation/anthropic/test_attributes.py
@@ -86,20 +86,64 @@ def test_get_stream_attributes():
     assert attributes[SpanAttributes.LLM_REQUEST_MODEL] == "claude-3-opus-20240229"
 
 
-def test_get_stream_event_attributes_start(mock_stream_event):
-    """Test extraction of stream start event attributes."""
-    attributes = get_stream_event_attributes(mock_stream_event)
-    assert attributes[SpanAttributes.LLM_RESPONSE_ID] == "msg_123"
-    assert attributes[SpanAttributes.LLM_RESPONSE_MODEL] == "claude-3-opus-20240229"
-    assert attributes[MessageAttributes.COMPLETION_ID.format(i=0)] == "msg_123"
+def test_get_stream_event_attributes_sequence(mock_stream_event, mock_message_stop_event):
+    """Test extraction of attributes from a sequence of stream events."""
+    # Test MessageStartEvent
+    start_attributes = get_stream_event_attributes(mock_stream_event)
+    assert start_attributes[SpanAttributes.LLM_RESPONSE_ID] == "msg_123"
+    assert start_attributes[SpanAttributes.LLM_RESPONSE_MODEL] == "claude-3-opus-20240229"
+    assert start_attributes[MessageAttributes.COMPLETION_ID.format(i=0)] == "msg_123"
+
+    # Test MessageStopEvent
+    stop_attributes = get_stream_event_attributes(mock_message_stop_event)
+    assert stop_attributes[SpanAttributes.LLM_RESPONSE_STOP_REASON] == "stop_sequence"
+    assert stop_attributes[SpanAttributes.LLM_RESPONSE_FINISH_REASON] == "stop_sequence"
+    assert stop_attributes[MessageAttributes.COMPLETION_FINISH_REASON.format(i=0)] == "stop_sequence"
 
 
-def test_get_stream_event_attributes_stop(mock_message_stop_event):
-    """Test extraction of stream stop event attributes."""
-    attributes = get_stream_event_attributes(mock_message_stop_event)
-    assert attributes[SpanAttributes.LLM_RESPONSE_STOP_REASON] == "stop_sequence"
-    assert attributes[SpanAttributes.LLM_RESPONSE_FINISH_REASON] == "stop_sequence"
-    assert attributes[MessageAttributes.COMPLETION_FINISH_REASON.format(i=0)] == "stop_sequence"
+def test_get_stream_event_attributes_raw_message_start():
+    """Test extraction of raw message start event attributes."""
+
+    class MockUsage:
+        def __init__(self):
+            self.input_tokens = 10
+            self.output_tokens = 5
+
+    class MockMessage:
+        def __init__(self):
+            self.usage = MockUsage()
+
+    class MockRawMessageStartEvent:
+        def __init__(self):
+            self.message = MockMessage()
+            self.__class__.__name__ = "RawMessageStartEvent"
+
+    event = MockRawMessageStartEvent()
+    attributes = get_stream_event_attributes(event)
+
+    assert attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 10
+    assert attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 5
+    assert attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 15
+
+
+def test_get_stream_event_attributes_raw_message_delta():
+    """Test extraction of raw message delta event attributes."""
+
+    class MockDelta:
+        def __init__(self):
+            self.stop_reason = "end_turn"
+
+    class MockRawMessageDeltaEvent:
+        def __init__(self):
+            self.delta = MockDelta()
+            self.__class__.__name__ = "RawMessageDeltaEvent"
+
+    event = MockRawMessageDeltaEvent()
+    attributes = get_stream_event_attributes(event)
+
+    assert attributes[SpanAttributes.LLM_RESPONSE_STOP_REASON] == "end_turn"
+    assert attributes[SpanAttributes.LLM_RESPONSE_FINISH_REASON] == "end_turn"
+    assert attributes[MessageAttributes.COMPLETION_FINISH_REASON.format(i=0)] == "end_turn"
 
 
 # Tool Attributes Tests
@@ -166,3 +210,19 @@ def test_get_tool_attributes_mixed_content():
     attributes = get_tool_attributes(content)
     assert MessageAttributes.COMPLETION_TOOL_CALL_NAME.format(i=0, j=0) in attributes
     assert attributes[MessageAttributes.COMPLETION_TOOL_CALL_NAME.format(i=0, j=0)] == "calculator"
+
+
+def test_get_message_attributes_with_stream(mock_stream_event, mock_message_stop_event):
+    """Test extraction of attributes from a Stream object."""
+
+    # Test MessageStartEvent attributes
+    start_attributes = get_stream_event_attributes(mock_stream_event)
+    assert start_attributes[SpanAttributes.LLM_RESPONSE_ID] == "msg_123"
+    assert start_attributes[SpanAttributes.LLM_RESPONSE_MODEL] == "claude-3-opus-20240229"
+    assert start_attributes[MessageAttributes.COMPLETION_ID.format(i=0)] == "msg_123"
+
+    # Test MessageStopEvent attributes
+    stop_attributes = get_stream_event_attributes(mock_message_stop_event)
+    assert stop_attributes[SpanAttributes.LLM_RESPONSE_STOP_REASON] == "stop_sequence"
+    assert stop_attributes[SpanAttributes.LLM_RESPONSE_FINISH_REASON] == "stop_sequence"
+    assert stop_attributes[MessageAttributes.COMPLETION_FINISH_REASON.format(i=0)] == "stop_sequence"


### PR DESCRIPTION
## 📥 Pull Request
Closes #977 

**📘 Description**
The key changes are:
 - Added support for the Stream type from Anthropic
 
This means the instrumentation now properly handles both:
 - Synchronous responses (regular API calls)
 - Streaming responses (when using the `stream=True`)
 
**🧪 Testing**
Tested all the Anthropic notebook examples 

