### PR TITLE
Lazy Loading of LLM Libraries to Prevent Duplicate Instrumentation

### DIFF
--- a/agentops/instrumentation/__init__.py
+++ b/agentops/instrumentation/__init__.py
@@ -1,18 +1,185 @@
-from typing import Optional
+"""
+AgentOps Instrumentation Module
+
+This module provides automatic instrumentation for various LLM providers and agentic libraries.
+It works by monitoring Python imports and automatically instrumenting packages as they are imported.
+
+Key Features:
+- Automatic detection and instrumentation of LLM providers (OpenAI, Anthropic, etc.)
+- Support for agentic libraries (CrewAI, AutoGen, etc.)
+- Version-aware instrumentation (only activates for supported versions)
+- Smart handling of provider vs agentic library conflicts
+- Non-intrusive monitoring using Python's import system
+"""
+
+from typing import Optional, Set
 from types import ModuleType
 from dataclasses import dataclass
 import importlib
 import sys
 from importlib.metadata import version
 from packaging.version import Version, parse
+import builtins
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 
 from agentops.logging import logger
 from agentops.sdk.core import TracingCore
 
-_active_instrumentors: list[BaseInstrumentor] = []
 
+class InstrumentationManager:
+    """
+    Manages the instrumentation state and provides methods for monitoring and instrumenting packages.
+    This is implemented as a singleton to maintain consistent state across the application.
+    """
+
+    def __init__(self):
+        # List of currently active instrumentors
+        self._active_instrumentors: list[BaseInstrumentor] = []
+        # Store the original import function to restore it later
+        self._original_import = builtins.__import__
+        # Track packages currently being instrumented to prevent recursion
+        self._instrumenting_packages: Set[str] = set()
+        # Flag to track if an agentic library is currently instrumented
+        self._has_agentic_library: bool = False
+
+    def is_package_instrumented(self, package_name: str) -> bool:
+        """Check if a package is already instrumented by looking at active instrumentors."""
+        return any(
+            instrumentor.__class__.__name__.lower().startswith(package_name.lower())
+            for instrumentor in self._active_instrumentors
+        )
+
+    def should_instrument_package(self, package_name: str) -> bool:
+        """
+        Determine if a package should be instrumented based on current state.
+        Handles special cases for agentic libraries and providers.
+        """
+        # If this is an agentic library, uninstrument all providers first
+        if package_name in AGENTIC_LIBRARIES:
+            self.uninstrument_providers()
+            self._has_agentic_library = True
+            logger.debug(f"Uninstrumented all providers due to agentic library {package_name} detection")
+            return True
+
+        # Skip providers if an agentic library is already instrumented
+        if package_name in PROVIDERS and self._has_agentic_library:
+            logger.debug(
+                f"Skipping provider {package_name} instrumentation as an agentic library is already instrumented"
+            )
+            return False
+
+        # Skip if already instrumented
+        if self.is_package_instrumented(package_name):
+            logger.debug(f"Package {package_name} is already instrumented")
+            return False
+
+        return True
+
+    def uninstrument_providers(self):
+        """Uninstrument all provider instrumentors while keeping agentic libraries active."""
+        providers_to_remove = []
+        for instrumentor in self._active_instrumentors:
+            if any(
+                instrumentor.__class__.__name__.lower().startswith(provider.lower()) for provider in PROVIDERS.keys()
+            ):
+                instrumentor.uninstrument()
+                logger.debug(f"Uninstrumented provider {instrumentor.__class__.__name__}")
+                providers_to_remove.append(instrumentor)
+
+        self._active_instrumentors = [i for i in self._active_instrumentors if i not in providers_to_remove]
+
+    def _import_monitor(self, name: str, globals=None, locals=None, fromlist=(), level=0):
+        """
+        Monitor imports and instrument packages as they are imported.
+        This replaces the built-in import function to intercept package imports.
+        """
+        root = name.split(".", 1)[0]
+
+        # Skip providers if an agentic library is already instrumented
+        if self._has_agentic_library and root in PROVIDERS:
+            return self._original_import(name, globals, locals, fromlist, level)
+
+        # Check if this is a package we should instrument
+        if (
+            root in TARGET_PACKAGES
+            and root not in self._instrumenting_packages
+            and not self.is_package_instrumented(root)
+        ):
+            logger.debug(f"Detected import of {root}")
+            self._instrumenting_packages.add(root)
+            try:
+                if not self.should_instrument_package(root):
+                    return self._original_import(name, globals, locals, fromlist, level)
+
+                # Get the appropriate configuration for the package
+                config = PROVIDERS.get(root) or AGENTIC_LIBRARIES[root]
+                loader = InstrumentorLoader(**config)
+
+                if loader.should_activate:
+                    instrumentor = instrument_one(loader)
+                    if instrumentor is not None:
+                        self._active_instrumentors.append(instrumentor)
+            except Exception as e:
+                logger.error(f"Error instrumenting {root}: {str(e)}")
+            finally:
+                self._instrumenting_packages.discard(root)
+
+        return self._original_import(name, globals, locals, fromlist, level)
+
+    def start_monitoring(self):
+        """Start monitoring imports and check already imported packages."""
+        builtins.__import__ = self._import_monitor
+        self._check_existing_imports()
+
+    def stop_monitoring(self):
+        """Stop monitoring imports and restore the original import function."""
+        builtins.__import__ = self._original_import
+
+    def _check_existing_imports(self):
+        """Check and instrument packages that were already imported before monitoring started."""
+        for name in list(sys.modules.keys()):
+            module = sys.modules.get(name)
+            if not isinstance(module, ModuleType):
+                continue
+
+            root = name.split(".", 1)[0]
+            if self._has_agentic_library and root in PROVIDERS:
+                continue
+
+            if (
+                root in TARGET_PACKAGES
+                and root not in self._instrumenting_packages
+                and not self.is_package_instrumented(root)
+            ):
+                self._instrumenting_packages.add(root)
+                try:
+                    if not self.should_instrument_package(root):
+                        continue
+
+                    config = PROVIDERS.get(root) or AGENTIC_LIBRARIES[root]
+                    loader = InstrumentorLoader(**config)
+
+                    if loader.should_activate:
+                        instrumentor = instrument_one(loader)
+                        if instrumentor is not None:
+                            self._active_instrumentors.append(instrumentor)
+                except Exception as e:
+                    logger.error(f"Error instrumenting {root}: {str(e)}")
+                finally:
+                    self._instrumenting_packages.discard(root)
+
+    def uninstrument_all(self):
+        """Stop monitoring and uninstrument all packages."""
+        self.stop_monitoring()
+        for instrumentor in self._active_instrumentors:
+            instrumentor.uninstrument()
+            logger.debug(f"Uninstrumented {instrumentor.__class__.__name__}")
+        self._active_instrumentors = []
+        self._has_agentic_library = False
+
+
+# Configuration for supported LLM providers
 PROVIDERS = {
     "openai": {
         "module_name": "agentops.instrumentation.openai",
@@ -36,6 +203,7 @@ PROVIDERS = {
     },
 }
 
+# Configuration for supported agentic libraries
 AGENTIC_LIBRARIES = {
     "crewai": {
         "module_name": "agentops.instrumentation.crewai",
@@ -50,28 +218,18 @@ AGENTIC_LIBRARIES = {
     },
 }
 
+# Combine all target packages for monitoring
+TARGET_PACKAGES = set(PROVIDERS.keys()) | set(AGENTIC_LIBRARIES.keys())
 
-def get_active_libraries() -> set[str]:
-    """
-    Get all actively used libraries in the current execution context.
-    This includes both directly imported and indirectly imported libraries.
-    """
-    active_libs = set()
-
-    # Check sys.modules for direct imports
-    for name, module in sys.modules.items():
-        if isinstance(module, ModuleType):
-            root_package = name.split(".")[0]
-            if root_package in PROVIDERS or root_package in AGENTIC_LIBRARIES:
-                active_libs.add(root_package)
-
-    return active_libs
+# Create a single instance of the manager
+_manager = InstrumentationManager()
 
 
 @dataclass
 class InstrumentorLoader:
     """
     Represents a dynamically-loadable instrumentor.
+    Handles version checking and instantiation of instrumentors.
     """
 
     module_name: str
@@ -80,31 +238,29 @@ class InstrumentorLoader:
 
     @property
     def module(self) -> ModuleType:
-        """Reference to the instrumentor module."""
+        """Get the instrumentor module."""
         return importlib.import_module(self.module_name)
 
     @property
     def should_activate(self) -> bool:
-        """Is the provider/library available in the environment with correct version?"""
+        """Check if the package is available and meets version requirements."""
         try:
             provider_name = self.module_name.split(".")[-1]
             module_version = version(provider_name)
-
-            if module_version is None:
-                logger.warning(f"Cannot determine {provider_name} version.")
-                return False
-
-            return Version(module_version) >= parse(self.min_version)
+            return module_version is not None and Version(module_version) >= parse(self.min_version)
         except ImportError:
             return False
 
     def get_instance(self) -> BaseInstrumentor:
-        """Return a new instance of the instrumentor."""
+        """Create and return a new instance of the instrumentor."""
         return getattr(self.module, self.class_name)()
 
 
 def instrument_one(loader: InstrumentorLoader) -> Optional[BaseInstrumentor]:
-    """Instrument a single instrumentor."""
+    """
+    Instrument a single package using the provided loader.
+    Returns the instrumentor instance if successful, None otherwise.
+    """
     if not loader.should_activate:
         logger.debug(
             f"Package {loader.module_name} not found or version < {loader.min_version}; skipping instrumentation"
@@ -114,53 +270,27 @@ def instrument_one(loader: InstrumentorLoader) -> Optional[BaseInstrumentor]:
     instrumentor = loader.get_instance()
     instrumentor.instrument(tracer_provider=TracingCore.get_instance()._provider)
     logger.debug(f"Instrumented {loader.class_name}")
-
     return instrumentor
 
 
 def instrument_all():
-    """
-    Instrument all available instrumentors.
-    This function is called when `instrument_llm_calls` is enabled.
-    """
-    global _active_instrumentors
-
-    if len(_active_instrumentors):
-        logger.debug("Instrumentors have already been populated.")
-        return
-
-    # Get all active libraries
-    active_libs = get_active_libraries()
-    logger.debug(f"Active libraries detected: {active_libs}")
-
-    # First check for agentic libraries
-    agentic_detected = False
-    for lib_name, lib_config in AGENTIC_LIBRARIES.items():
-        if lib_name in active_libs:
-            loader = InstrumentorLoader(**lib_config)
-            if loader.should_activate:
-                agentic_detected = True
-                instrumentor = instrument_one(loader)
-                if instrumentor is not None:
-                    _active_instrumentors.append(instrumentor)
-
-    # If no agentic libraries are detected, instrument active providers
-    if not agentic_detected:
-        for provider_name, provider_config in PROVIDERS.items():
-            if provider_name in active_libs:
-                loader = InstrumentorLoader(**provider_config)
-                instrumentor = instrument_one(loader)
-                if instrumentor is not None:
-                    _active_instrumentors.append(instrumentor)
+    """Start monitoring and instrumenting packages if not already started."""
+    if not _manager._active_instrumentors:
+        _manager.start_monitoring()
 
 
 def uninstrument_all():
+    """Stop monitoring and uninstrument all packages."""
+    _manager.uninstrument_all()
+
+
+def get_active_libraries() -> set[str]:
     """
-    Uninstrument all available instrumentors.
-    This can be called to disable instrumentation.
+    Get all actively used libraries in the current execution context.
+    Returns a set of package names that are currently imported and being monitored.
     """
-    global _active_instrumentors
-    for instrumentor in _active_instrumentors:
-        instrumentor.uninstrument()
-        logger.debug(f"Uninstrumented {instrumentor.__class__.__name__}")
-    _active_instrumentors = []
+    return {
+        name.split(".")[0]
+        for name, module in sys.modules.items()
+        if isinstance(module, ModuleType) and name.split(".")[0] in TARGET_PACKAGES
+    }

--- a/agentops/instrumentation/__init__.py
+++ b/agentops/instrumentation/__init__.py
@@ -2,35 +2,81 @@ from typing import Optional
 from types import ModuleType
 from dataclasses import dataclass
 import importlib
+import sys
+from importlib.metadata import version
+from packaging.version import Version, parse
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 
 from agentops.logging import logger
 from agentops.sdk.core import TracingCore
 
-
-# references to all active instrumentors
 _active_instrumentors: list[BaseInstrumentor] = []
+
+PROVIDERS = {
+    "openai": {
+        "module_name": "agentops.instrumentation.openai",
+        "class_name": "OpenAIInstrumentor",
+        "min_version": "1.0.0",
+    },
+    "anthropic": {
+        "module_name": "agentops.instrumentation.anthropic",
+        "class_name": "AnthropicInstrumentor",
+        "min_version": "0.32.0",
+    },
+    "google.genai": {
+        "module_name": "agentops.instrumentation.google_generativeai",
+        "class_name": "GoogleGenerativeAIInstrumentor",
+        "min_version": "0.1.0",
+    },
+    "ibm_watsonx_ai": {
+        "module_name": "agentops.instrumentation.ibm_watsonx_ai",
+        "class_name": "IBMWatsonXInstrumentor",
+        "min_version": "0.1.0",
+    },
+}
+
+AGENTIC_LIBRARIES = {
+    "crewai": {
+        "module_name": "agentops.instrumentation.crewai",
+        "class_name": "CrewAIInstrumentor",
+        "min_version": "0.56.0",
+    },
+    "autogen": {"module_name": "agentops.instrumentation.ag2", "class_name": "AG2Instrumentor", "min_version": "0.1.0"},
+    "agents": {
+        "module_name": "agentops.instrumentation.openai_agents",
+        "class_name": "OpenAIAgentsInstrumentor",
+        "min_version": "0.1.0",
+    },
+}
+
+
+def get_active_libraries() -> set[str]:
+    """
+    Get all actively used libraries in the current execution context.
+    This includes both directly imported and indirectly imported libraries.
+    """
+    active_libs = set()
+
+    # Check sys.modules for direct imports
+    for name, module in sys.modules.items():
+        if isinstance(module, ModuleType):
+            root_package = name.split(".")[0]
+            if root_package in PROVIDERS or root_package in AGENTIC_LIBRARIES:
+                active_libs.add(root_package)
+
+    return active_libs
 
 
 @dataclass
 class InstrumentorLoader:
     """
-        Represents a dynamically-loadable instrumentor.
-
-        This class is used to load and activate instrumentors based on their module
-    and class names.
-        We use the `provider_import_name` to determine if the library is installed i
-    n the environment.
-
-        `module_name` is the name of the module to import from.
-        `class_name` is the name of the class to instantiate from the module.
-        `provider_import_name` is the name of the package to check for availability.
+    Represents a dynamically-loadable instrumentor.
     """
 
     module_name: str
     class_name: str
-    provider_import_name: str
+    min_version: str
 
     @property
     def module(self) -> ModuleType:
@@ -39,10 +85,16 @@ class InstrumentorLoader:
 
     @property
     def should_activate(self) -> bool:
-        """Is the provider import available in the environment?"""
+        """Is the provider/library available in the environment with correct version?"""
         try:
-            importlib.import_module(self.provider_import_name)
-            return True
+            provider_name = self.module_name.split(".")[-1]
+            module_version = version(provider_name)
+
+            if module_version is None:
+                logger.warning(f"Cannot determine {provider_name} version.")
+                return False
+
+            return Version(module_version) >= parse(self.min_version)
         except ImportError:
             return False
 
@@ -51,51 +103,11 @@ class InstrumentorLoader:
         return getattr(self.module, self.class_name)()
 
 
-available_instrumentors: list[InstrumentorLoader] = [
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.openai",
-        class_name="OpenAIInstrumentor",
-        provider_import_name="openai",
-    ),
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.anthropic",
-        class_name="AnthropicInstrumentor",
-        provider_import_name="anthropic",
-    ),
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.crewai",
-        class_name="CrewAIInstrumentor",
-        provider_import_name="crewai",
-    ),
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.openai_agents",
-        class_name="OpenAIAgentsInstrumentor",
-        provider_import_name="agents",
-    ),
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.google_generativeai",
-        class_name="GoogleGenerativeAIInstrumentor",
-        provider_import_name="google.genai",
-    ),
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.ibm_watsonx_ai",
-        class_name="IBMWatsonXInstrumentor",
-        provider_import_name="ibm_watsonx_ai",
-    ),
-    InstrumentorLoader(
-        module_name="agentops.instrumentation.ag2",
-        class_name="AG2Instrumentor",
-        provider_import_name="autogen",
-    ),
-]
-
-
 def instrument_one(loader: InstrumentorLoader) -> Optional[BaseInstrumentor]:
     """Instrument a single instrumentor."""
     if not loader.should_activate:
-        # this package is not in the environment; skip
         logger.debug(
-            f"Package {loader.provider_import_name} not found; skipping instrumentation of {loader.class_name}"
+            f"Package {loader.module_name} not found or version < {loader.min_version}; skipping instrumentation"
         )
         return None
 
@@ -117,15 +129,29 @@ def instrument_all():
         logger.debug("Instrumentors have already been populated.")
         return
 
-    for loader in available_instrumentors:
-        if loader.class_name in _active_instrumentors:
-            # already instrumented
-            logger.debug(f"Instrumentor {loader.class_name} has already been instrumented.")
-            return None
+    # Get all active libraries
+    active_libs = get_active_libraries()
+    logger.debug(f"Active libraries detected: {active_libs}")
 
-        instrumentor = instrument_one(loader)
-        if instrumentor is not None:
-            _active_instrumentors.append(instrumentor)
+    # First check for agentic libraries
+    agentic_detected = False
+    for lib_name, lib_config in AGENTIC_LIBRARIES.items():
+        if lib_name in active_libs:
+            loader = InstrumentorLoader(**lib_config)
+            if loader.should_activate:
+                agentic_detected = True
+                instrumentor = instrument_one(loader)
+                if instrumentor is not None:
+                    _active_instrumentors.append(instrumentor)
+
+    # If no agentic libraries are detected, instrument active providers
+    if not agentic_detected:
+        for provider_name, provider_config in PROVIDERS.items():
+            if provider_name in active_libs:
+                loader = InstrumentorLoader(**provider_config)
+                instrumentor = instrument_one(loader)
+                if instrumentor is not None:
+                    _active_instrumentors.append(instrumentor)
 
 
 def uninstrument_all():

--- a/agentops/instrumentation/__init__.py
+++ b/agentops/instrumentation/__init__.py
@@ -12,7 +12,7 @@ Key Features:
 - Non-intrusive monitoring using Python's import system
 """
 
-from typing import Optional, Set
+from typing import Optional, Set, TypedDict
 from types import ModuleType
 from dataclasses import dataclass
 import importlib
@@ -179,8 +179,15 @@ class InstrumentationManager:
         self._has_agentic_library = False
 
 
+# Define the structure for instrumentor configurations
+class InstrumentorConfig(TypedDict):
+    module_name: str
+    class_name: str
+    min_version: str
+
+
 # Configuration for supported LLM providers
-PROVIDERS = {
+PROVIDERS: dict[str, InstrumentorConfig] = {
     "openai": {
         "module_name": "agentops.instrumentation.openai",
         "class_name": "OpenAIInstrumentor",
@@ -204,7 +211,7 @@ PROVIDERS = {
 }
 
 # Configuration for supported agentic libraries
-AGENTIC_LIBRARIES = {
+AGENTIC_LIBRARIES: dict[str, InstrumentorConfig] = {
     "crewai": {
         "module_name": "agentops.instrumentation.crewai",
         "class_name": "CrewAIInstrumentor",


### PR DESCRIPTION
We've been facing issues with duplicate LLM instrumentation when multiple instrumentors (openai, crewai etc.) try to wrap the same LLM calls. This leads to redundant spans and potential conflicts in tracing.
Refactoring instrumentation module to be independent of each other is eating me up for the past week :)
## The Solution
Me, @the-praxs and @fenilfaldu were discussing approaches to fix tightly coupled behavior and make it independent of each other. Thanks to @the-praxs (🐐) who came up with this solution from V3, we've implemented a lazy loading approach for LLM libraries. Instead of eagerly importing and instrumenting all possible LLM providers and agentic frameworks, we now check sys.modules for direct imports and prioritize Agentic Libararis over providers to eliminate redundant spans.

## Why This is Better
- Prevents duplicate instrumentation of the same LLM calls
- Reduces overhead by only instrumenting what's actually used
- More reliable than depending on other instrumentors' LLM call spans
- Cleaner traces with single spans per LLM call

## Required Changes to Agentic Libraries
With this change, we need to update our agentic library integrations to record their own LLM spans:
- **CrewAI**: Need to modify to record spans for its internal LLM calls
- **AutoGen**: Update to track LLM interactions within agent conversations
- **Agents SDK**: Add span recording for direct LLM calls

This ensures that even when these frameworks make LLM calls internally, we'll have proper visibility into their operations without duplicate instrumentation.

## Current Limitations
There's one known limitation: if a provider/agentic framework is imported in a separate file and then imported into the main file, we miss it. For example:

```python
# llm_caller.py (helper file)
from anthropic import Anthropic  # This import might be missed

def call_anthropic():
    client = Anthropic()
    return client.messages.create(...)

# main.py
from llm_caller import call_anthropic  # We detect this import but miss the underlying Anthropic import
```
Possible fix is to scan imported modules' source files for additional imports

## Testing
I've done some testing with this approach and found it to be more reliable than our previous method. It successfully prevents duplicate spans but we still need to update crewai, autogen and agents instrumentations.