### PR TITLE
Rename root span

### DIFF
--- a/agentops/__init__.py
+++ b/agentops/__init__.py
@@ -61,6 +61,7 @@ def init(
     log_level: Optional[Union[str, int]] = None,
     fail_safe: Optional[bool] = None,
     exporter_endpoint: Optional[str] = None,
+    session_name: Optional[str] = None,
     **kwargs,
 ):
     """
@@ -88,6 +89,7 @@ def init(
         fail_safe (bool): Whether to suppress errors and continue execution when possible.
         exporter_endpoint (str, optional): Endpoint for the exporter. If none is provided, key will
             be read from the AGENTOPS_EXPORTER_ENDPOINT environment variable.
+        session_name (str, optional): Name of the session to be used in the span attributes.
         **kwargs: Additional configuration parameters to be passed to the client.
     """
     global _client
@@ -116,6 +118,7 @@ def init(
         log_level=log_level,
         fail_safe=fail_safe,
         exporter_endpoint=exporter_endpoint,
+        session_name=session_name,
         **kwargs,
     )
 

--- a/agentops/client/client.py
+++ b/agentops/client/client.py
@@ -101,9 +101,12 @@ class Client:
 
             # Pass default_tags if they exist
             if self.config.default_tags:
-                session = start_session(tags=list(self.config.default_tags))
+                logger.debug(f"Starting session with tags: {self.config.default_tags}")
+                logger.debug(f"Starting session with name: {self.config.session_name}")
+                session = start_session(session_name=self.config.session_name, tags=list(self.config.default_tags))
             else:
-                session = start_session()
+                logger.debug("Starting session without tags")
+                session = start_session(session_name=self.config.session_name)
 
             # Register this session globally
             global _active_session

--- a/agentops/client/client.py
+++ b/agentops/client/client.py
@@ -99,14 +99,19 @@ class Client:
         if self.config.auto_start_session:
             from agentops.legacy import start_session
 
-            # Pass default_tags if they exist
-            if self.config.default_tags:
+            if self.config.default_tags and self.config.session_name:
                 logger.debug(f"Starting session with tags: {self.config.default_tags}")
                 logger.debug(f"Starting session with name: {self.config.session_name}")
                 session = start_session(session_name=self.config.session_name, tags=list(self.config.default_tags))
-            else:
-                logger.debug("Starting session without tags")
+            elif self.config.default_tags:
+                logger.debug(f"Starting session with tags: {self.config.default_tags}")
+                session = start_session(tags=list(self.config.default_tags))
+            elif self.config.session_name:
+                logger.debug(f"Starting session with name: {self.config.session_name}")
                 session = start_session(session_name=self.config.session_name)
+            else:
+                logger.debug("Starting session without tags or name")
+                session = start_session()
 
             # Register this session globally
             global _active_session

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -124,6 +124,11 @@ class Config:
         default_factory=lambda: None, metadata={"description": "Custom span processor for OpenTelemetry trace data"}
     )
 
+    session_name: Optional[str] = field(
+        default_factory=lambda: None,
+        metadata={"description": "Name of the session to be used in the span attributes"},
+    )
+
     def configure(
         self,
         api_key: Optional[str] = None,
@@ -144,6 +149,7 @@ class Config:
         exporter: Optional[SpanExporter] = None,
         processor: Optional[SpanProcessor] = None,
         exporter_endpoint: Optional[str] = None,
+        session_name: Optional[str] = None,
     ):
         """Configure settings from kwargs, validating where necessary"""
         if api_key is not None:
@@ -214,6 +220,9 @@ class Config:
         # else:
         #     self.exporter_endpoint = self.endpoint
 
+        if session_name is not None:
+            self.session_name = session_name
+            
     def dict(self):
         """Return a dictionary representation of the config"""
         return {
@@ -235,6 +244,7 @@ class Config:
             "exporter": self.exporter,
             "processor": self.processor,
             "exporter_endpoint": self.exporter_endpoint,
+            "session_name": self.session_name,
         }
 
     def json(self):

--- a/agentops/config.py
+++ b/agentops/config.py
@@ -222,7 +222,7 @@ class Config:
 
         if session_name is not None:
             self.session_name = session_name
-            
+
     def dict(self):
         """Return a dictionary representation of the config"""
         return {

--- a/agentops/instrumentation/crewai/instrumentation.py
+++ b/agentops/instrumentation/crewai/instrumentation.py
@@ -174,7 +174,6 @@ def wrap_kickoff(
         tag_list = list(config.default_tags)
         attributes[SpanAttributes.AGENTOPS_SPAN_TAGS] = tag_list
 
-
     with tracer.start_as_current_span(
         name=span_name,
         kind=SpanKind.INTERNAL,
@@ -344,12 +343,12 @@ def wrap_agent_execute_task(
     attributes = {
         SpanAttributes.AGENTOPS_SPAN_KIND: AgentOpsSpanKindValues.AGENT.value,
     }
-    
+
     config = get_client().config
     if config.default_tags and len(config.default_tags) > 0:
         tag_list = list(config.default_tags)
         attributes[SpanAttributes.AGENTOPS_SPAN_TAGS] = tag_list
-        
+
     with tracer.start_as_current_span(
         f"{agent_name}.agent",
         kind=SpanKind.CLIENT,

--- a/agentops/legacy/__init__.py
+++ b/agentops/legacy/__init__.py
@@ -73,7 +73,9 @@ class Session:
             _flush_span_processors()
 
 
-def _create_session_span(session_name: Optional[str] = None, tags: Union[Dict[str, Any], List[str], None] = None) -> tuple:
+def _create_session_span(
+    session_name: Optional[str] = None, tags: Union[Dict[str, Any], List[str], None] = None
+) -> tuple:
     """
     Helper function to create a session span with tags.
 
@@ -94,7 +96,7 @@ def _create_session_span(session_name: Optional[str] = None, tags: Union[Dict[st
     attributes = {}
     if tags:
         attributes["tags"] = tags
-    
+
     span_name = "session" if session_name is None else session_name
     return _make_span(span_name, span_kind=SpanKind.SESSION, attributes=attributes)
 

--- a/agentops/legacy/__init__.py
+++ b/agentops/legacy/__init__.py
@@ -73,7 +73,7 @@ class Session:
             _flush_span_processors()
 
 
-def _create_session_span(tags: Union[Dict[str, Any], List[str], None] = None) -> tuple:
+def _create_session_span(session_name: Optional[str] = None, tags: Union[Dict[str, Any], List[str], None] = None) -> tuple:
     """
     Helper function to create a session span with tags.
 
@@ -94,10 +94,13 @@ def _create_session_span(tags: Union[Dict[str, Any], List[str], None] = None) ->
     attributes = {}
     if tags:
         attributes["tags"] = tags
-    return _make_span("session", span_kind=SpanKind.SESSION, attributes=attributes)
+    
+    span_name = "session" if session_name is None else session_name
+    return _make_span(span_name, span_kind=SpanKind.SESSION, attributes=attributes)
 
 
 def start_session(
+    session_name: Optional[str] = None,
     tags: Union[Dict[str, Any], List[str], None] = None,
 ) -> Session:
     """
@@ -153,7 +156,7 @@ def start_session(
             _current_session = dummy_session
             return dummy_session
 
-    span, ctx, token = _create_session_span(tags)
+    span, ctx, token = _create_session_span(session_name, tags)
     session = Session(span, token)
 
     # Set the global session reference

--- a/agentops/semconv/span_attributes.py
+++ b/agentops/semconv/span_attributes.py
@@ -86,6 +86,7 @@ class SpanAttributes:
     AGENTOPS_ENTITY_INPUT = "agentops.entity.input"
     AGENTOPS_SPAN_KIND = "agentops.span.kind"
     AGENTOPS_ENTITY_NAME = "agentops.entity.name"
+    AGENTOPS_SPAN_TAGS = "tags"
 
     # Operation attributes
     OPERATION_NAME = "operation.name"

--- a/docs/v1/concepts/sessions.mdx
+++ b/docs/v1/concepts/sessions.mdx
@@ -27,6 +27,7 @@ Optionally, sessions may include:
 - **Tags**: Tags allow for the categorization and later retrieval of sessions.
 - **Host Environment**: Automatically gathers basic information about the system on which the session ran.
 - **Video**: If applicable, an optional video recording of the session.
+- **Session Name**: A custom name for the session that helps identify and organize different types of sessions in the dashboard. Can be set during initialization or when starting a session.
 
 ### Methods
 #### `end_session`

--- a/docs/v1/usage/sdk-reference.mdx
+++ b/docs/v1/usage/sdk-reference.mdx
@@ -26,6 +26,7 @@ The first element of AgentOps is always calling .init()
 - `auto_start_session` (bool): Whether to start a session automatically when the client is created. You may wish to delay starting a session in order to do additional setup or starting a session on a child process.
 - `inherited_session_id` (str, optional): When creating the client, passing in this value will connect the client to an existing session. This is useful when having separate processes contribute to the same session.
 - `skip_auto_end_session` (bool, optional): If you are using a framework such as Crew, the framework can decide when to halt execution. Setting this parameter to true will not end your agentops session when this happens.
+- `session_name` (str, optional): Name of the session to be used in the span attributes. This helps identify and organize different types of sessions in the dashboard.
 
 **Returns**:
 

--- a/docs/v2/concepts/sessions.mdx
+++ b/docs/v2/concepts/sessions.mdx
@@ -13,6 +13,19 @@ import agentops
 agentops.init(api_key="YOUR_API_KEY", tags=["production"])
 ```
 
+You can also provide a custom name for your session during initialization:
+
+```python
+import agentops
+
+# Initialize with a custom session name
+agentops.init(
+    api_key="YOUR_API_KEY",
+    session_name="customer-support-bot",
+    tags=["production"]
+)
+```
+
 This approach:
 - Creates a session automatically when you initialize the SDK
 - Tracks all events in the context of this session

--- a/docs/v2/concepts/tags.mdx
+++ b/docs/v2/concepts/tags.mdx
@@ -13,6 +13,7 @@ import agentops
 agentops.init(
     api_key="YOUR_API_KEY",
     tags=["production", "customer-service", "gpt-4"]
+    session_name="customer-support-agent"
 )
 ```
 

--- a/docs/v2/usage/sdk-reference.mdx
+++ b/docs/v2/usage/sdk-reference.mdx
@@ -33,6 +33,7 @@ Initializes the AgentOps SDK and automatically starts tracking your application.
 - `fail_safe` (bool, optional): Whether to suppress errors and continue execution when possible. Defaults to False.
 - `exporter_endpoint` (str, optional): Endpoint for the exporter. If not provided, will be read from the `AGENTOPS_EXPORTER_ENDPOINT` environment variable. Defaults to 'https://otlp.agentops.ai/v1/traces'.
 - `export_flush_interval` (int, optional): Time interval in milliseconds between automatic exports of telemetry data. Defaults to 1000.
+- `session_name` (str, optional): Name of the session to be used in the span attributes. This helps identify and organize different types of sessions in the dashboard.
 
 **Returns**:
 


### PR DESCRIPTION
## 📥 Pull Request
closes #988 

**📘 Description**
- Added a new `session_name` parameter to the `init()` function.
- This parameter allows users to give custom names to their sessions
- Default value is `session`, maintaining backward compatibility.
- Added session name support in CrewAI instrumentation.
- Updated SDK reference documentation to include the new parameter
- Added examples showing how to use the `session_name` parameter.


**🧪 Testing**
![Screenshot 2025-05-23 at 2 36 34 AM](https://github.com/user-attachments/assets/590fd438-cb93-48ed-a384-5d65c4906d9d)

