### PR TITLE
version unpin and upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentops"
-version = "0.4.13"
+version = "0.4.14"
 authors = [
   { name="Alex Reibman", email="areibman@gmail.com" },
   { name="Shawn Qiu", email="siyangqiu@gmail.com" },
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "Observability and DevTool Platform for AI Agents"
 # readme = "README.md"
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## 📥 Pull Request

Can't install on projects with python version >3.14. Big issue, IDK why we had it pinned. 

Therefore not able to install in Suna