### PR TITLE
fixed psutil conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.0.0,<3.0.0",
-    "psutil>=5.9.8,<6.1.0",
+    "psutil>=5.9.8,<7.0.1",
     "termcolor>=2.3.0,<2.5.0",
     "PyYAML>=5.3,<7.0",
     "packaging>=21.0,<25.0", # Lower bound of 21.0 ensures compatibility with Python 3.9+


### PR DESCRIPTION
📥 Pull Request

**📘 Description**
Closes #1006.

Changed `psutil` version cap from `<6.1.0` to `<7.0.1`. Based on the [commit history](https://github.com/AgentOps-AI/agentops/commit/47beecf571f39aeb7d7220dd0f4afabab11689b3), the previous cap merely reflects the max version at the time.

**🧪 Testing**
Tested on the CrewAI markdown_validator notebook.