### PR TITLE
Fix xAI icon path

### DIFF
--- a/docs/v2/introduction.mdx
+++ b/docs/v2/introduction.mdx
@@ -22,7 +22,7 @@ description: "AgentOps is the developer favorite platform for testing, debugging
   <Card title="OpenAI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/openai/openai-logomark.png?raw=true" alt="OpenAI" />} iconType="image" href="/v2/integrations/openai" />
   <Card title="LiteLLM" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/litellm/litellm.png?raw=true" alt="LiteLLM" />} iconType="image" href="/v2/integrations/litellm" />
   <Card title="Watsonx" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/ibm/ibm-logo.svg?raw=true" alt="IBM" />} iconType="image" href="/v2/integrations/ibm_watsonx_ai" />
-  <Card title="x.AI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/xai/xai-logo.svg?raw=true" alt="x.AI" />} iconType="image" href="/v2/integrations/xai" />
+  <Card title="x.AI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/xai/xai-logo.png?raw=true" alt="x.AI" />} iconType="image" href="/v2/integrations/xai" />
 </CardGroup>
 
 ### Agent Frameworks


### PR DESCRIPTION
## Summary
- fix xAI icon path on v2 docs introduction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_684a0ffe7c5c8321aa110272edc86041