### PR TITLE
Fix CrewAI LLM docs

### DIFF
--- a/docs/v2/integrations/crewai.mdx
+++ b/docs/v2/integrations/crewai.mdx
@@ -6,23 +6,23 @@ description: 'AgentOps and CrewAI teamed up to make monitoring Crew agents dead 
 [CrewAI](https://www.crewai.com/) is a framework for easily building multi-agent applications. AgentOps integrates with CrewAI to provide observability into your agent workflows. Crew has comprehensive [documentation](https://docs.crewai.com) available as well as a great [quickstart](https://docs.crewai.com/how-to/Creating-a-Crew-and-kick-it-off/) guide.
 
 ## Installation
-Install AgentOps and CrewAI, along with `python-dotenv` for managing API keys and `langchain-openai` for the LLM:
+Install AgentOps and CrewAI, along with `python-dotenv` for managing API keys:
 
 <CodeGroup>
   ```bash pip
-  pip install agentops crewai python-dotenv langchain-openai
+  pip install agentops crewai python-dotenv
   ```
   ```bash poetry
-  poetry add agentops crewai python-dotenv langchain-openai
+  poetry add agentops crewai python-dotenv
   ```
   ```bash uv
-  uv add agentops crewai python-dotenv langchain-openai
+  uv add agentops crewai python-dotenv
   ```
 </CodeGroup>
 
 ## Setting Up API Keys
 
-You'll need API keys for AgentOps and OpenAI (since `ChatOpenAI` is commonly used with CrewAI):
+You'll need API keys for AgentOps and OpenAI (since CrewAI's built-in `LLM` uses OpenAI models by default):
 - **OPENAI_API_KEY**: From the [OpenAI Platform](https://platform.openai.com/api-keys)
 - **AGENTOPS_API_KEY**: From your [AgentOps Dashboard](https://app.agentops.ai/)
 
@@ -52,22 +52,21 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 ## Usage
 
-Simply initialize AgentOps at the beginning of your CrewAI application. AgentOps will automatically instrument CrewAI and LangChain components (like `ChatOpenAI`) to track your agent interactions.
+Simply initialize AgentOps at the beginning of your CrewAI application. AgentOps automatically instruments CrewAI components—including its `LLM`—to track your agent interactions.
 
 Here's how to set up a basic CrewAI application with AgentOps:
 
 ```python
 import agentops
-from crewai import Agent, Task, Crew
-from langchain_openai import ChatOpenAI
+from crewai import Agent, Task, Crew, LLM
 
 # Initialize AgentOps client
 agentops.init()
 
 # Define the LLM to use with CrewAI
-llm = ChatOpenAI(
-    model="gpt-4", # Or your preferred model
-    temperature=0.7
+llm = LLM(
+    model="openai/gpt-4o",  # Or your preferred model
+    temperature=0.7,
 )
 
 # Create an agent


### PR DESCRIPTION
## Summary
- update CrewAI integration guide to use `LLM` instead of ChatOpenAI

## Testing
- `pre-commit run --files docs/v2/integrations/crewai.mdx`
- `pytest -q tests/unit` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_684a306c8cc08321b0751b90ca763906