### PR TITLE
Quiet pip installs in OpenAI Agents notebooks

### DIFF
--- a/examples/openai_agents/agent_guardrails.ipynb
+++ b/examples/openai_agents/agent_guardrails.ipynb
@@ -18,9 +18,9 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "%pip install agentops\n",
-    "%pip install openai-agents\n",
-    "%pip install dotenv pydantic"
+    "%pip install -q agentops\n",
+    "%pip install -q openai-agents\n",
+    "%pip install -q dotenv pydantic"
    ]
   },
   {

--- a/examples/openai_agents/agent_patterns.ipynb
+++ b/examples/openai_agents/agent_patterns.ipynb
@@ -57,9 +57,9 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "%pip install agentops\n",
-    "%pip install openai-agents\n",
-    "%pip install pydotenv"
+    "%pip install -q agentops\n",
+    "%pip install -q openai-agents\n",
+    "%pip install -q pydotenv"
    ]
   },
   {

--- a/examples/openai_agents/agents_tools.ipynb
+++ b/examples/openai_agents/agents_tools.ipynb
@@ -41,9 +41,9 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "%pip install agentops\n",
-    "%pip install openai-agents\n",
-    "%pip install pydotenv"
+    "%pip install -q agentops\n",
+    "%pip install -q openai-agents\n",
+    "%pip install -q pydotenv"
    ]
   },
   {

--- a/examples/openai_agents/customer_service_agent.ipynb
+++ b/examples/openai_agents/customer_service_agent.ipynb
@@ -38,9 +38,9 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "%pip install agentops\n",
-    "%pip install openai-agents\n",
-    "%pip install pydotenv"
+    "%pip install -q agentops\n",
+    "%pip install -q openai-agents\n",
+    "%pip install -q pydotenv"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- revert unintended mass notebook changes
- add `-q` to `%pip install` lines in OpenAI Agents examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b950b92e48321ab2ec96443dd3843