### PR TITLE
Limit span resource attributes

### DIFF
--- a/agentops/sdk/attributes.py
+++ b/agentops/sdk/attributes.py
@@ -60,8 +60,8 @@ def get_global_resource_attributes(
     """
     Get all global resource attributes for telemetry.
 
-    Combines service metadata, system information, and imported libraries
-    into a complete resource attributes dictionary.
+    Combines service metadata and imported libraries into a complete
+    resource attributes dictionary.
 
     Args:
         service_name: Name of the service
@@ -73,7 +73,6 @@ def get_global_resource_attributes(
     # Start with service attributes
     attributes: dict[str, Any] = {
         ResourceAttributes.SERVICE_NAME: service_name,
-        **get_system_resource_attributes(),
     }
 
     if project_id:

--- a/agentops/sdk/core.py
+++ b/agentops/sdk/core.py
@@ -23,6 +23,7 @@ from agentops.sdk.attributes import (
     get_trace_attributes,
     get_span_attributes,
     get_session_end_attributes,
+    get_system_resource_attributes,
 )
 from agentops.semconv import SpanKind
 from agentops.helpers.dashboard import log_trace_url
@@ -352,8 +353,9 @@ class TracingCore:
             logger.warning("Global tracer not initialized. Cannot start trace.")
             return None
 
-        # Build trace attributes
+        # Build trace attributes and include system metadata only for session spans
         attributes = get_trace_attributes(tags=tags)
+        attributes.update(get_system_resource_attributes())
 
         # make_span creates and starts the span, and activates it in the current context
         # It returns: span, context_object, context_token


### PR DESCRIPTION
## Summary
- restrict global resource attributes to basic service info
- add system details only for session spans

## Testing
- `pre-commit run --files agentops/sdk/attributes.py agentops/sdk/core.py`
- `pytest tests/unit/sdk -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc127ad5083218f326767573ec42c