### PR TITLE
Streamline docs sidebar and fix image

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -27,38 +27,7 @@
     "name": "Docs",
     "icon": "lines-leaning"
   },
-  "anchors": [
-    {
-      "name": "Chat With Docs",
-      "icon": "user-doctor-message",
-      "url": "https://entelligence.ai/AgentOps-AI&agentops"
-    },
-    {
-      "name": "Your Dashboard",
-      "icon": "chart-tree-map",
-      "url": "https://app.agentops.ai"
-    },
-    {
-      "name": "Discord",
-      "icon": "discord",
-      "url": "https://discord.gg/UgJyyxx7uc"
-    },
-    {
-      "name": "GitHub",
-      "icon": "github",
-      "url": "https://github.com/AgentOps-AI"
-    },
-    {
-      "name": "Call my Agent (Support)",
-      "icon": "headset",
-      "url": "https://agentops.ai/contact"
-    },
-    {
-      "name": "Give Feedback",
-      "icon": "comment-smile",
-      "url": "https://agentops.ai/contact"
-    }
-  ],
+  "anchors": [],
   "versions": ["v2", "v1", "v0"],
   "navigation": [
     {

--- a/docs/v1/usage/dashboard-info.mdx
+++ b/docs/v1/usage/dashboard-info.mdx
@@ -14,12 +14,12 @@ You also get helpful debugging info such as any SDK versions you were on if you'
 LLM calls are presented as a familiar chat history view, and charts give you a breakdown of the types of events that were called and how long they took.
 
 <Frame type="glass" caption="Session Summary">
-  <img height="200" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/session-summary.gif?raw=true" />
+  <img height="200" src="/images/session-summary.gif" />
 </Frame>
 
 Find any past sessions from your Session Drawer.
 <Frame type="glass" caption="Session Drawer">
-  <img height="250" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/session-drawer.gif?raw=true" />
+  <img height="250" src="/images/session-drawer.gif" />
 </Frame>
 
 Most powerful of all is the Session Waterfall. On the left, a time visualization of all your LLM calls, Action events, Tool calls, and Errors.
@@ -27,14 +27,14 @@ On the right, specific details about the event you've selected on the waterfall.
 Most of which has been automatically recorded for you.
 
 <Frame type="glass" caption="Session Waterfall">
-  <img height="200" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/session-waterfall.gif?raw=true" />
+  <img height="200" src="/images/session-waterfall.gif" />
 </Frame>
 
 
 ### Session Overview
 View a meta-analysis of all of your sessions in a single view.
 <Frame type="glass" caption="Session Overview">
-  <img height="200" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/overview.png?raw=true" />
+  <img height="200" src="/images/overview.png" />
 </Frame>
 
 <script type="module" src="/scripts/github_stars.js"></script>

--- a/docs/v2/introduction.mdx
+++ b/docs/v2/introduction.mdx
@@ -5,7 +5,7 @@ description: "AgentOps is the developer favorite platform for testing, debugging
 <iframe
   width="100%"
   height="300"
-  src="https://www.youtube.com/embed/Lc5IGi66FpQ"
+  src="https://www.youtube.com/watch?v=EU_A3_ux09s"
   title="AgentOps Introduction"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen

--- a/docs/v2/usage/dashboard-info.mdx
+++ b/docs/v2/usage/dashboard-info.mdx
@@ -13,12 +13,12 @@ You also get helpful debugging info such as any SDK versions you were on if you'
 LLM calls are presented as a familiar chat history view, and charts give you a breakdown of the types of events that were called and how long they took.
 
 <Frame type="glass" caption="Session Summary">
-  <img height="200" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/session-summary.gif?raw=true" />
+  <img height="200" src="/images/session-summary.gif" />
 </Frame>
 
 Find any past sessions from your Session Drawer.
 <Frame type="glass" caption="Session Drawer">
-  <img height="250" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/session-drawer.gif?raw=true" />
+  <img height="250" src="/images/session-drawer.gif" />
 </Frame>
 
 Most powerful of all is the Session Waterfall. On the left, a time visualization of all your LLM calls, Action events, Tool calls, and Errors.
@@ -26,14 +26,14 @@ On the right, specific details about the event you've selected on the waterfall.
 Most of which has been automatically recorded for you.
 
 <Frame type="glass" caption="Session Waterfall">
-  <img height="200" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/session-waterfall.gif?raw=true" />
+  <img height="200" src="/images/session-waterfall.gif" />
 </Frame>
 
 
 ### Session Overview
 View a meta-analysis of all of your sessions in a single view.
 <Frame type="glass" caption="Session Overview">
-  <img height="200" src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/overview.png?raw=true" />
+  <img height="200" src="/images/overview.png" />
 </Frame>
 
 <script type="module" src="/scripts/github_stars.js"></script>


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
*   Removed the initial set of links from the docs sidebar to reduce clutter and improve navigation.
*   Fixed broken image references in `dashboard-info.mdx` files by updating them to local paths, resolving dead image issues and improving page load performance.

**🧪 Testing**
*   Confirmed the specified links are no longer present in the docs sidebar.
*   Verified that all images in the "Session Drilldown" section of both v1 and v2 documentation now load correctly.