### PR TITLE
Switch llm providers and frameworks sections

### DIFF
--- a/docs/v2/introduction.mdx
+++ b/docs/v2/introduction.mdx
@@ -19,18 +19,6 @@ Prefer asking your IDE? Install the Mintlify <a href="/v2/usage/mcp-docs"><stron
 
 ## Integrate with developer favorite LLM providers and agent frameworks
 
-### LLM Providers
-
-<CardGroup cols={2}>
-  <Card title="Anthropic" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/anthropic/anthropic_icon_slate.png?raw=true" alt="Anthropic" />} iconType="image" href="/v2/integrations/anthropic" />
-  <Card title="Google Generative AI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/deepmind/gemini-logo.png?raw=true" alt="Gemini" />} iconType="image" href="/v2/integrations/google_generative_ai" />
-  <Card title="OpenAI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/openai/openai-logomark.png?raw=true" alt="OpenAI" />} iconType="image" href="/v2/integrations/openai" />
-  <Card title="LiteLLM" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/litellm/litellm.png?raw=true" alt="LiteLLM" />} iconType="image" href="/v2/integrations/litellm" />
-  <Card title="Watsonx" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/ibm/ibm-logo.svg?raw=true" alt="IBM" />} iconType="image" href="/v2/integrations/ibm_watsonx_ai" />
-  <Card title="x.AI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/xai/xai-logo.png?raw=true" alt="x.AI" />} iconType="image" href="/v2/integrations/xai" />
-  <Card title="Mem0" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/mem0/mem0.png?raw=true" alt="Mem0" />} iconType="image" href="/v2/integrations/mem0" />
-</CardGroup>
-
 ### Agent Frameworks
 
 <CardGroup cols={2}>
@@ -43,6 +31,18 @@ Prefer asking your IDE? Install the Mintlify <a href="/v2/usage/mcp-docs"><stron
   <Card title="OpenAI Agents (Python)" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/openai/openai-logomark.png?raw=true" alt="OpenAI Agents Python" />} iconType="image" href="/v2/integrations/openai_agents_python" />
   <Card title="OpenAI Agents (TypeScript)" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/openai/openai-logomark.png?raw=true" alt="OpenAI Agents JS" />} iconType="image" href="/v2/integrations/openai_agents_js" />
   <Card title="Smolagents" icon={<img src="https://github.com/AgentOps-AI/agentops/blob/main/docs/images/external/huggingface/hf-logo.png?raw=true" alt="smolagents" />} iconType="image" href="/v2/integrations/smolagents" />
+</CardGroup>
+
+### LLM Providers
+
+<CardGroup cols={2}>
+  <Card title="Anthropic" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/anthropic/anthropic_icon_slate.png?raw=true" alt="Anthropic" />} iconType="image" href="/v2/integrations/anthropic" />
+  <Card title="Google Generative AI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/deepmind/gemini-logo.png?raw=true" alt="Gemini" />} iconType="image" href="/v2/integrations/google_generative_ai" />
+  <Card title="OpenAI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/openai/openai-logomark.png?raw=true" alt="OpenAI" />} iconType="image" href="/v2/integrations/openai" />
+  <Card title="LiteLLM" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/litellm/litellm.png?raw=true" alt="LiteLLM" />} iconType="image" href="/v2/integrations/litellm" />
+  <Card title="Watsonx" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/ibm/ibm-logo.svg?raw=true" alt="IBM" />} iconType="image" href="/v2/integrations/ibm_watsonx_ai" />
+  <Card title="x.AI" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/xai/xai-logo.png?raw=true" alt="x.AI" />} iconType="image" href="/v2/integrations/xai" />
+  <Card title="Mem0" icon={<img src="https://www.github.com/agentops-ai/agentops/blob/main/docs/images/external/mem0/mem0.png?raw=true" alt="Mem0" />} iconType="image" href="/v2/integrations/mem0" />
 </CardGroup>
 
 Observability and monitoring for your AI agents and LLM apps. And we do it all in just two lines of code...


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Switched the order of the "LLM Providers" and "Agent Frameworks" sections on the `v2/introduction.mdx` page. "Agent Frameworks" now appears before "LLM Providers".

**🧪 Testing**
Verified the section order in `docs/v2/introduction.mdx` to confirm "Agent Frameworks" is now listed before "LLM Providers".