### PR TITLE
Prevent errors when instrumenting an agent using MCPToolset

### DIFF
--- a/agentops/instrumentation/agentic/google_adk/patch.py
+++ b/agentops/instrumentation/agentic/google_adk/patch.py
@@ -360,8 +360,10 @@ def extract_agent_attributes(instance):
         attributes["agent.instruction"] = instance.instruction
     if hasattr(instance, "tools"):
         for tool in instance.tools:
-            attributes[ToolAttributes.TOOL_NAME] = tool.name
-            attributes[ToolAttributes.TOOL_DESCRIPTION] = tool.description
+            if hasattr(tool, "name"):
+                attributes[ToolAttributes.TOOL_NAME] = tool.name
+            if hasattr(tool, "description"):
+                attributes[ToolAttributes.TOOL_DESCRIPTION] = tool.description
     if hasattr(instance, "output_key"):
         attributes["agent.output_key"] = instance.output_key
     # Subagents


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Not all tools come with a name and description. This change prevents errors when an ADK Agent has a MCPToolset in its tools[] array and likely fixes other errors as well by checking a tool name and description exists before accessing them.

**🧪 Testing**
After the changes, I can use the MCPToolset without errors.

