### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/docs/v1/integrations/autogen.mdx
+++ b/docs/v1/integrations/autogen.mdx
@@ -24,10 +24,10 @@ AgentOps and AG2 (Formerly AutoGen) teamed up to make monitoring AG2 agents dead
 	<Step title="Install AG2">
 		<CodeGroup>
 			```bash pip
-			pip install pyautogen
+			pip install ag2
 			```
 			```bash poetry
-			poetry add pyautogen
+			poetry add ag2
 			```
 		</CodeGroup>
 	</Step>

--- a/examples/autogen/README.md
+++ b/examples/autogen/README.md
@@ -7,7 +7,7 @@ This directory contains examples of using Microsoft AutoGen with AgentOps instru
 - Python >= 3.10 < 3.13
 - Install required dependencies:
   ```
-  pip install agentops "pyautogen[retrievechat]"
+  pip install agentops "ag2[retrievechat]"
   ```
 
 ## Examples


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
