### PR TITLE
Debug agentops attribute error in trace

### DIFF
--- a/AGENTOPS_TRACE_USAGE_GUIDE.md
+++ b/AGENTOPS_TRACE_USAGE_GUIDE.md
@@ -1,0 +1,176 @@
+# AgentOps Trace Usage Guide
+
+## The Error
+
+The user encountered this error:
+```python
+Traceback (most recent call last):
+  File "/Users/amirjaveed/PycharmProjects/CrewAiAgentOpsPythonProject/main.py", line 28, in <module>
+    with agentops.trace("debug_test"):
+AttributeError: 'str' object has no attribute '__enter__'. Did you mean: '__iter__'?
+```
+
+## Root Cause
+
+The error occurred because `agentops.trace` is a **decorator**, not a function that returns a context manager. When you call `agentops.trace("debug_test")`, it returns a decorator function (or a string in some cases), which cannot be used with the `with` statement.
+
+## Solution
+
+AgentOps provides two different ways to create traces:
+
+### 1. `agentops.start_trace()` - For Context Manager Usage
+
+Use `start_trace()` when you want to use a context manager (with statement):
+
+```python
+import agentops
+
+# Initialize AgentOps
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+# Use as a context manager
+with agentops.start_trace("debug_test") as trace_context:
+    print("Inside trace context")
+    # Your code here
+    # The trace automatically ends when exiting the context
+```
+
+### 2. `@agentops.trace` - For Decorator Usage
+
+Use `@trace` as a decorator for functions or classes:
+
+```python
+import agentops
+
+# Initialize AgentOps
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+# Use as a decorator
+@agentops.trace
+def my_function():
+    print("Inside traced function")
+    return "result"
+
+# Or with parameters
+@agentops.trace(name="custom_name", tags={"type": "demo"})
+def another_function(x, y):
+    return x + y
+```
+
+## Key Differences
+
+| Feature | `start_trace()` | `@trace` decorator |
+|---------|----------------|-------------------|
+| **Usage** | Context manager or manual | Function/class decorator |
+| **Syntax** | `with start_trace():` | `@trace` above function |
+| **Returns** | TraceContext object | Decorated function |
+| **Scope** | Explicit block of code | Entire function execution |
+| **Best for** | Dynamic tracing, conditional traces | Function-level instrumentation |
+
+## Complete Working Examples
+
+### Example 1: Context Manager (Recommended for your use case)
+```python
+import agentops
+
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+# This is what you wanted to do - use as a context manager
+with agentops.start_trace("debug_test") as trace_context:
+    print("Performing operations...")
+    # Your code here
+```
+
+### Example 2: Manual Trace Management
+```python
+import agentops
+
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+# Start trace manually
+trace_context = agentops.start_trace("manual_test")
+try:
+    # Your code here
+    print("Performing operations...")
+finally:
+    # End trace manually
+    agentops.end_trace(trace_context, end_state=agentops.SUCCESS)
+```
+
+### Example 3: Decorator on Functions
+```python
+import agentops
+
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+@agentops.trace
+def process_data(data):
+    # This entire function is traced
+    return data.upper()
+
+# Call the function normally
+result = process_data("hello")
+```
+
+### Example 4: Decorator on Classes
+```python
+import agentops
+
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+@agentops.trace(name="DataProcessor")
+class DataProcessor:
+    def __init__(self, config):
+        self.config = config
+    
+    def process(self, data):
+        return data
+
+# The class initialization is traced
+processor = DataProcessor({"setting": "value"})
+```
+
+## Common Pitfalls to Avoid
+
+1. **Don't use `trace()` as a function call for context managers**
+   ```python
+   # ❌ WRONG - This causes the AttributeError
+   with agentops.trace("test"):
+       pass
+   
+   # ✅ CORRECT - Use start_trace() instead
+   with agentops.start_trace("test"):
+       pass
+   ```
+
+2. **Don't forget to initialize AgentOps first**
+   ```python
+   # Always initialize before using traces
+   agentops.init(api_key="your_key", auto_start_session=False)
+   ```
+
+3. **Don't mix up the import**
+   - The `trace` from `agentops` is a decorator
+   - If you see examples using `with trace():`, they might be using a different library's trace function (e.g., from `openai-agents`)
+
+## Summary
+
+- Use `agentops.start_trace()` when you need a context manager (with statement)
+- Use `@agentops.trace` when you want to decorate functions or classes
+- Both methods achieve similar results but are suited for different use cases
+- The error you encountered was trying to use a decorator as a context manager
+
+The corrected version of your code should be:
+```python
+import agentops
+
+agentops.init(api_key="your_api_key", auto_start_session=False)
+
+# Replace this:
+# with agentops.trace("debug_test"):  # ❌ WRONG
+
+# With this:
+with agentops.start_trace("debug_test"):  # ✅ CORRECT
+    # Your code here
+    pass
+```

--- a/fixed_example.py
+++ b/fixed_example.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Corrected example showing proper AgentOps trace usage.
+
+The error occurred because agentops.trace is a decorator, not a function that returns a context manager.
+To use trace as a context manager, you should use agentops.start_trace() instead.
+"""
+
+import agentops
+import os
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+# Initialize AgentOps with your API key
+agentops.init(
+    api_key=os.getenv("AGENTOPS_API_KEY", "f700a1...7b69"),  # Replace with your actual key
+    auto_start_session=False  # Don't auto-start a session
+)
+
+# Method 1: Using start_trace() as a context manager (RECOMMENDED for context manager usage)
+print("\n=== Method 1: Using start_trace() as a context manager ===")
+with agentops.start_trace("debug_test") as trace_context:
+    print(f"Inside trace context: {trace_context}")
+    print("Performing some operations...")
+    # Your code here
+    print("Operations completed!")
+
+# Method 2: Using start_trace() and end_trace() manually
+print("\n=== Method 2: Manual trace management ===")
+trace_context = agentops.start_trace("manual_test")
+try:
+    print("Performing operations in manual trace...")
+    # Your code here
+    print("Manual operations completed!")
+finally:
+    agentops.end_trace(trace_context, end_state=agentops.SUCCESS)
+
+# Method 3: Using @trace decorator on functions (for function-level tracing)
+print("\n=== Method 3: Using @trace decorator ===")
+@agentops.trace
+def my_function():
+    print("Inside traced function")
+    return "Function result"
+
+result = my_function()
+print(f"Function returned: {result}")
+
+# Method 4: Using @trace decorator with parameters
+print("\n=== Method 4: Using @trace decorator with parameters ===")
+@agentops.trace(name="custom_trace_name", tags={"type": "demo"})
+def another_function(x, y):
+    print(f"Processing {x} and {y}")
+    return x + y
+
+result = another_function(5, 3)
+print(f"Result: {result}")
+
+print("\n=== All examples completed successfully! ===")


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Resolves an `AttributeError` that occurred when `agentops.trace` was incorrectly used as a context manager. This PR clarifies the distinction between `agentops.trace` (a decorator) and `agentops.start_trace()` (the function to use for context manager functionality).

Includes:
- A new `AGENTOPS_TRACE_USAGE_GUIDE.md` explaining the correct usage of AgentOps tracing methods.
- A `fixed_example.py` demonstrating all valid ways to use AgentOps tracing, including `start_trace()` as a context manager.

**🧪 Testing**
The `fixed_example.py` was created and executed successfully, demonstrating that `agentops.start_trace()` correctly functions as a context manager and that other tracing methods (manual start/end, decorators) work as intended without errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-386bfafd-40f0-4bf6-8ff6-2bb4e7c4a1e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-386bfafd-40f0-4bf6-8ff6-2bb4e7c4a1e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

