### PR TITLE
docs: highlight open source links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@
   <img src="https://img.shields.io/github/commit-activity/m/agentops-ai/agentops" alt="git commit activity">
   </a>
   <img src="https://img.shields.io/pypi/v/agentops?&color=3670A0" alt="PyPI - Version">
-  <a href="https://github.com/AgentOps-AI/agentops-ts">
-    <img src="https://img.shields.io/badge/TypeScript%20SDK-Available-blue?&color=3670A0" alt="TypeScript SDK">
-  </a>
   <a href="https://opensource.org/licenses/MIT">
     <img src="https://img.shields.io/badge/License-MIT-yellow.svg?&color=3670A0" alt="License: MIT">
   </a>
@@ -54,6 +51,10 @@
 <br/>
 
 AgentOps helps developers build, evaluate, and monitor AI agents. From prototype to production.
+
+## Open Source
+
+The AgentOps app is open source under the MIT license. Explore the code in our [app directory](https://github.com/AgentOps-AI/agentops/tree/main/app).
 
 ## Key Integrations 🔌
 

--- a/app/api/agentops/agentops.code-workspace
+++ b/app/api/agentops/agentops.code-workspace
@@ -5,10 +5,7 @@
     },
     {
       "path": "../.."
-    },
-    {
-      "path": "../../../agentops-ts"
     }
   ],
-  "settings": {},
+  "settings": {}
 }

--- a/app/api/agentops/agentops.code-workspace
+++ b/app/api/agentops/agentops.code-workspace
@@ -5,7 +5,10 @@
     },
     {
       "path": "../.."
+    },
+    {
+      "path": "../../../agentops-ts"
     }
   ],
-  "settings": {}
+  "settings": {},
 }

--- a/docs/v1/introduction.mdx
+++ b/docs/v1/introduction.mdx
@@ -4,6 +4,10 @@ description: "AgentOps is the developer favorite platform for testing, debugging
 mode: "wide"
 ---
 
+<Note title="Open Source">
+The AgentOps app is open source—explore the code in our <a href="https://github.com/AgentOps-AI/agentops/tree/main/app">GitHub app directory</a>.
+</Note>
+
 ## Integrate with developer favorite agent frameworks
 
 <CardGroup cols={2}>

--- a/docs/v1/quickstart.mdx
+++ b/docs/v1/quickstart.mdx
@@ -5,6 +5,10 @@ description: "Start using AgentOps with just 2 lines of code"
 import CodeTooltip from '/snippets/add-code-tooltip.mdx'
 import EnvTooltip from '/snippets/add-env-tooltip.mdx'
 
+<Note title="Open Source">
+The AgentOps app is open source—explore the code in our <a href="https://github.com/AgentOps-AI/agentops/tree/main/app">GitHub app directory</a>.
+</Note>
+
 <Steps>
   <Step title="Install the AgentOps SDK">
     <CodeGroup>

--- a/docs/v2/introduction.mdx
+++ b/docs/v2/introduction.mdx
@@ -17,6 +17,11 @@ Prefer asking your IDE? Install the Mintlify <a href="/v2/usage/mcp-docs"><stron
 </Note>
 
 
+<Note title="Open Source">
+The AgentOps app is open source. Browse the code or contribute in our <a href="https://github.com/AgentOps-AI/agentops/tree/main/app">GitHub app directory</a>.
+</Note>
+
+
 ## Integrate with developer favorite LLM providers and agent frameworks
 
 ### Agent Frameworks

--- a/docs/v2/quickstart.mdx
+++ b/docs/v2/quickstart.mdx
@@ -7,6 +7,10 @@ AgentOps is designed for easy integration into your AI agent projects, providing
 
 <Check>[Give us a star on GitHub!](https://github.com/AgentOps-AI/agentops) Your support helps us grow. ⭐</Check>
 
+<Note title="Open Source">
+The AgentOps app is open source—explore the code in our <a href="https://github.com/AgentOps-AI/agentops/tree/main/app">GitHub app directory</a>.
+</Note>
+
 <Note title="Chat with the docs in your IDE">
 Prefer asking your IDE? Install the Mintlify <a href="/v2/usage/mcp-docs"><strong>MCP Docs Server</strong></a> for AgentOps to chat with the docs while you code:
 `npx mint-mcp add agentops`

--- a/docs/v2/usage/typescript-sdk.mdx
+++ b/docs/v2/usage/typescript-sdk.mdx
@@ -132,13 +132,8 @@ chat().then(() => {
 });
 ```
 
-## Repository Links
-
-- **Modern SDK**: [agentops-ts](https://github.com/AgentOps-AI/agentops-ts)
-- **Legacy SDK**: [agentops-node](https://github.com/AgentOps-AI/agentops-node)
-
 ## Getting Help
 
 - [Discord Community](https://discord.gg/FagdcwwXRR)
-- [GitHub Issues](https://github.com/AgentOps-AI/agentops-ts/issues)
+- [GitHub Issues](https://github.com/AgentOps-AI/agentops/issues)
 - [Documentation](https://docs.agentops.ai)


### PR DESCRIPTION
## Summary
- clarify open source availability with new section in main README
- add open source links to v1 and v2 documentation introductions and quickstart guides
- remove obsolete agentops-ts references from docs and workspace

## Testing
- `pre-commit run --files README.md docs/v1/introduction.mdx docs/v1/quickstart.mdx docs/v2/introduction.mdx docs/v2/quickstart.mdx docs/v2/usage/typescript-sdk.mdx app/api/agentops/agentops.code-workspace`


------
https://chatgpt.com/codex/tasks/task_e_68b61c71f87c832182517f9ad4a863d9