### PR TITLE
Fix local development console errors

### DIFF
--- a/app/dashboard/app/providers/posthog-provider.tsx
+++ b/app/dashboard/app/providers/posthog-provider.tsx
@@ -11,13 +11,16 @@ import { PostHogProvider as PHProvider } from 'posthog-js/react';
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    const isProd = process.env.NODE_ENV === 'production';
+    const enableInDev = process.env.NEXT_PUBLIC_ENABLE_POSTHOG_IN_DEV === 'true';
 
-    // Only initialize PostHog if we have a valid key
-    if (posthogKey) {
+    // Only initialize PostHog if we have a valid key and it's production
+    // or explicitly enabled for development.
+    if (posthogKey && (isProd || enableInDev)) {
       posthog.init(posthogKey, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
-        person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
-        capture_pageview: false, // Disable automatic pageview capture, as we capture manually
+        person_profiles: 'identified_only',
+        capture_pageview: false,
       });
     }
   }, []);

--- a/app/dashboard/app/signin/auth-form.tsx
+++ b/app/dashboard/app/signin/auth-form.tsx
@@ -40,6 +40,11 @@ export function AuthForm() {
     }
 
     const checkAuth = async () => {
+      // If there is no session cookie, skip calling the API to avoid 401 spam in dev
+      if (typeof document !== 'undefined' && !document.cookie.includes('session_id=')) {
+        setIsCheckingAuth(false);
+        return;
+      }
       try {
         const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/opsboard/users/me`, {
           method: 'GET',

--- a/app/dashboard/app/signin/components.tsx
+++ b/app/dashboard/app/signin/components.tsx
@@ -15,7 +15,7 @@ import { GithubIcon as Github, Loading03Icon as Loader } from 'hugeicons-react';
 import { MagicWand01Icon as WandSparkles } from 'hugeicons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import posthog from 'posthog-js';
+// posthog is not required directly in this file; remove unused import to prevent bundling warnings
 import { useState, useEffect } from 'react';
 import { toast } from '@/components/ui/use-toast';
 

--- a/app/dashboard/app/simple-login/page.tsx
+++ b/app/dashboard/app/simple-login/page.tsx
@@ -52,6 +52,10 @@ const SimpleLoginPageDev = () => {
   const authBaseUrl = `${apiUrl}/auth`;
 
   const checkAuthAndFetchDetails = async () => {
+    // Avoid unnecessary 401s in local mode: if there is no session cookie, skip the check
+    if (typeof document !== 'undefined' && !document.cookie.includes('session_id=')) {
+      return false;
+    }
     const lastLoginMethod = localStorage.getItem('loginMethodUsed') as LoginType | null;
     if (loginMethodUsed !== lastLoginMethod) {
       setLoginMethodUsed(lastLoginMethod);


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
This PR addresses the excessive console errors in local development mode by:
*   Gating PostHog initialization to only run in production or when explicitly enabled via `NEXT_PUBLIC_ENABLE_POSTHOG_IN_DEV=true`.
*   Adding checks to `signin` and `simple-login` pages to prevent unnecessary `/opsboard/users/me` API calls (and subsequent 401 errors) when no `session_id` cookie is present.
*   Removing an unused PostHog import.

These changes significantly reduce console noise, improving the local development experience.

**🧪 Testing**
1.  **Without logging in:** Hard refresh `/signin` or `/simple-login`. Verify that the console is clean, with no PostHog 401/404 errors or `/opsboard/users/me` 401 errors.
2.  **After logging in:** Log in as a user. Verify that the application functions normally and that relevant requests (including `/opsboard/users/me`) are made without the previous noise.
3.  **(Optional) Enable PostHog in dev:** Set `NEXT_PUBLIC_ENABLE_POSTHOG_IN_DEV=true` in `.env.local` and provide PostHog keys. Verify PostHog initializes and sends events in dev mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccc587b5-d790-4b16-8f91-a4f816d574cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ccc587b5-d790-4b16-8f91-a4f816d574cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

