### PR TITLE
fix: skip wrapping missing google.adk telemetry functions

### DIFF
--- a/agentops/instrumentation/agentic/google_adk/patch.py
+++ b/agentops/instrumentation/agentic/google_adk/patch.py
@@ -658,6 +658,10 @@ def _patch_module_function(module_name: str, function_name: str, wrapper_functio
     """Helper to patch module-level functions."""
     try:
         module = __import__(module_name, fromlist=[function_name])
+        if not hasattr(module, function_name):
+            # Function may not exist in this version of the module - skip silently
+            logger.debug(f"{module_name}.{function_name} not found in this version, skipping")
+            return
         wrapt.wrap_function_wrapper(module, function_name, wrapper_function(agentops_tracer))
         _wrapped_methods.append((module, function_name))
         logger.debug(f"Successfully wrapped {module_name}.{function_name}")


### PR DESCRIPTION
## Summary

Fixes #1257

When using AgentOps with `google-adk>=1.5.0`, users see a confusing warning:
```
Could not wrap google.adk.telemetry.trace_tool_response: module 'google.adk.telemetry' has no attribute 'trace_tool_response'
```

This happens because `trace_tool_response` was removed/renamed in newer versions of google-adk, but `_patch_module_function` treats all failures the same (warning level).

## Fix

Added a `hasattr()` check in `_patch_module_function` before attempting to wrap. If the function doesn't exist in the current module version, it logs at `debug` level and returns early, avoiding the confusing warning.