### PR TITLE
fix(openai): isolate beta.chat wrappers to prevent cascade failure

### DIFF
--- a/agentops/instrumentation/providers/openai/instrumentor.py
+++ b/agentops/instrumentation/providers/openai/instrumentor.py
@@ -109,19 +109,6 @@ class OpenaiInstrumentor(CommonInstrumentor):
                     async_chat_completion_stream_wrapper(self._tracer),
                 )
 
-                # Beta chat completion streaming wrappers
-                wrap_function_wrapper(
-                    "openai.resources.beta.chat.completions",
-                    "Completions.parse",
-                    chat_completion_stream_wrapper(self._tracer),
-                )
-
-                wrap_function_wrapper(
-                    "openai.resources.beta.chat.completions",
-                    "AsyncCompletions.parse",
-                    async_chat_completion_stream_wrapper(self._tracer),
-                )
-
                 # Responses API streaming wrappers
                 wrap_function_wrapper(
                     "openai.resources.responses",
@@ -136,6 +123,24 @@ class OpenaiInstrumentor(CommonInstrumentor):
                 )
             except Exception as e:
                 logger.warning(f"[OPENAI INSTRUMENTOR] Error setting up OpenAI streaming wrappers: {e}")
+
+            # Beta chat completion wrappers (separate try/except because
+            # openai.resources.beta.chat was removed in newer openai SDK
+            # versions; a failure here should not prevent the main streaming
+            # wrappers from being applied).
+            try:
+                wrap_function_wrapper(
+                    "openai.resources.beta.chat.completions",
+                    "Completions.parse",
+                    chat_completion_stream_wrapper(self._tracer),
+                )
+                wrap_function_wrapper(
+                    "openai.resources.beta.chat.completions",
+                    "AsyncCompletions.parse",
+                    async_chat_completion_stream_wrapper(self._tracer),
+                )
+            except Exception:
+                pass  # Module not available in this openai version
         else:
             if not is_openai_v1():
                 logger.debug("[OPENAI INSTRUMENTOR] Skipping custom wrapping - not using OpenAI v1")


### PR DESCRIPTION
## Summary

When the openai SDK removes `openai.resources.beta.chat` (as in newer versions), the entire streaming wrapper setup fails because all wrappers share a single `try/except` block. This means even the valid `chat.completions` and `responses` wrappers are never applied, breaking all streaming instrumentation.

## Changes

- Move the `beta.chat.completions` wrappers into their own `try/except` block
- A missing beta module now only affects beta wrappers, not all streaming instrumentation
- The main `chat.completions` and `responses` wrappers are always applied regardless of beta availability

Fixes #1260