### PR TITLE
Fix AttributeError on None tool attributes in response

### DIFF
--- a/agentops/instrumentation/providers/openai/attributes/response.py
+++ b/agentops/instrumentation/providers/openai/attributes/response.py
@@ -503,7 +503,7 @@ def get_response_tool_web_search_attributes(tool: "WebSearchTool", index: int) -
     if hasattr(tool, "search_context_size"):
         parameters["search_context_size"] = tool.search_context_size
 
-    if hasattr(tool, "user_location"):
+    if hasattr(tool, "user_location") and tool.user_location is not None:
         parameters["user_location"] = tool.user_location.__dict__
 
     tool_data = tool.__dict__
@@ -521,13 +521,13 @@ def get_response_tool_file_search_attributes(tool: "FileSearchTool", index: int)
     if hasattr(tool, "vector_store_ids"):
         parameters["vector_store_ids"] = tool.vector_store_ids
 
-    if hasattr(tool, "filters"):
+    if hasattr(tool, "filters") and tool.filters is not None:
         parameters["filters"] = tool.filters.__dict__
 
     if hasattr(tool, "max_num_results"):
         parameters["max_num_results"] = tool.max_num_results
 
-    if hasattr(tool, "ranking_options"):
+    if hasattr(tool, "ranking_options") and tool.ranking_options is not None:
         parameters["ranking_options"] = tool.ranking_options.__dict__
 
     tool_data = tool.__dict__

--- a/tests/unit/instrumentation/openai_core/test_response_attributes.py
+++ b/tests/unit/instrumentation/openai_core/test_response_attributes.py
@@ -612,6 +612,22 @@ class TestResponseAttributes:
             assert "search_context_size" in result[MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0)]
             assert "user_location" in result[MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0)]
 
+    def test_get_response_tool_web_search_attributes_none_user_location(self):
+        """Test web search tool handles None user_location without crashing"""
+        web_search_tool = MockWebSearchTool(
+            {"type": "web_search_preview", "search_context_size": "medium", "user_location": None}
+        )
+
+        with patch("agentops.instrumentation.providers.openai.attributes.response.WebSearchTool", MockWebSearchTool):
+            result = get_response_tool_web_search_attributes(web_search_tool, 0)
+
+            assert isinstance(result, dict)
+            assert MessageAttributes.TOOL_CALL_NAME.format(i=0) in result
+            assert result[MessageAttributes.TOOL_CALL_NAME.format(i=0)] == "web_search_preview"
+            # user_location should not appear in parameters since it's None
+            args = result.get(MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0), "")
+            assert "user_location" not in args
+
     def test_get_response_tool_file_search_attributes(self):
         """Test extraction of attributes from file search tool"""
         # Create a mock file search tool
@@ -643,6 +659,29 @@ class TestResponseAttributes:
             assert "filters" in result[MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0)]
             assert "max_num_results" in result[MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0)]
             assert "ranking_options" in result[MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0)]
+
+    def test_get_response_tool_file_search_attributes_none_filters_and_ranking(self):
+        """Test file search tool handles None filters and ranking_options without crashing"""
+        file_search_tool = MockFileSearchTool(
+            {
+                "type": "file_search",
+                "vector_store_ids": ["store_123"],
+                "filters": None,
+                "max_num_results": 5,
+                "ranking_options": None,
+            }
+        )
+
+        with patch("agentops.instrumentation.providers.openai.attributes.response.FileSearchTool", MockFileSearchTool):
+            result = get_response_tool_file_search_attributes(file_search_tool, 0)
+
+            assert isinstance(result, dict)
+            assert MessageAttributes.TOOL_CALL_TYPE.format(i=0) in result
+            assert result[MessageAttributes.TOOL_CALL_TYPE.format(i=0)] == "file_search"
+            # filters and ranking_options should not appear in parameters since they're None
+            args = result.get(MessageAttributes.TOOL_CALL_ARGUMENTS.format(i=0), "")
+            assert "filters" not in args
+            assert "ranking_options" not in args
 
     def test_get_response_tool_computer_attributes(self):
         """Test extraction of attributes from computer tool"""


### PR DESCRIPTION
Add `is not None` checks for `user_location`, `filters`, and `ranking_options`                                               
  before accessing `__dict__`, preventing crash when these optional fields
  default to `None`.

  Fixes #1285

  ## 📥 Pull Request

  **📘 Description**
  When using the OpenAI Agents SDK with file search or web search tools, the `on_span_end` method crashes with `AttributeError:
  'NoneType' object has no attribute '__dict__'`. This happens because `user_location`, `filters`, and `ranking_options` are
  optional fields that default to `None` in the OpenAI SDK, but the code only checks `hasattr()` (which returns `True` even when
  the value is `None`) before calling `.__dict__`.

  This PR adds `is not None` guards to all three locations in `response.py`:
  - `get_response_tool_web_search_attributes`: `tool.user_location`
  - `get_response_tool_file_search_attributes`: `tool.filters` and `tool.ranking_options`

  **🧪 Testing**
  Added two new unit tests:
  - `test_get_response_tool_web_search_attributes_none_user_location` — verifies `user_location=None` is handled gracefully
  - `test_get_response_tool_file_search_attributes_none_filters_and_ranking` — verifies `filters=None` and `ranking_options=None`
   are handled gracefully

  All 15 tests in `test_response_attributes.py` pass.