### PR TITLE
fix: add None checks to prevent __dict__ crash on optional tool attributes

### DIFF
--- a/agentops/instrumentation/providers/openai/attributes/response.py
+++ b/agentops/instrumentation/providers/openai/attributes/response.py
@@ -503,7 +503,7 @@ def get_response_tool_web_search_attributes(tool: "WebSearchTool", index: int) -
     if hasattr(tool, "search_context_size"):
         parameters["search_context_size"] = tool.search_context_size
 
-    if hasattr(tool, "user_location"):
+    if hasattr(tool, "user_location") and tool.user_location is not None:
         parameters["user_location"] = tool.user_location.__dict__
 
     tool_data = tool.__dict__
@@ -521,13 +521,13 @@ def get_response_tool_file_search_attributes(tool: "FileSearchTool", index: int)
     if hasattr(tool, "vector_store_ids"):
         parameters["vector_store_ids"] = tool.vector_store_ids
 
-    if hasattr(tool, "filters"):
+    if hasattr(tool, "filters") and tool.filters is not None:
         parameters["filters"] = tool.filters.__dict__
 
     if hasattr(tool, "max_num_results"):
         parameters["max_num_results"] = tool.max_num_results
 
-    if hasattr(tool, "ranking_options"):
+    if hasattr(tool, "ranking_options") and tool.ranking_options is not None:
         parameters["ranking_options"] = tool.ranking_options.__dict__
 
     tool_data = tool.__dict__


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'NoneType' object has no attribute '__dict__'` crash in tool attribute extraction.

Fixes #1285.

## Problem

Three `hasattr()` checks in the tool attribute extraction guard calls to `.__dict__` on optional fields. But `hasattr()` returns `True` even when the attribute value is `None`, causing a crash:

```
ERROR:openai.agents:Error in trace processor ... during on_span_end: 'NoneType' object has no attribute '__dict__'
```

Affected fields:
- `WebSearchTool.user_location` (line 507)
- `FileSearchTool.filters` (line 525)
- `FileSearchTool.ranking_options` (line 531)

## Fix

Add `is not None` checks alongside the existing `hasattr()` guards:

```python
# Before
if hasattr(tool, "user_location"):
    parameters["user_location"] = tool.user_location.__dict__

# After
if hasattr(tool, "user_location") and tool.user_location is not None:
    parameters["user_location"] = tool.user_location.__dict__
```

Same pattern applied to all three affected fields.

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin
