### PR TITLE
Fix broken links to AG2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ pip install 'crewai[agentops]'
 ### AG2 🤖
 With only two lines of code, add full observability and monitoring to AG2 (formerly AutoGen) agents. Set an `AGENTOPS_API_KEY` in your environment and call `agentops.init()`
 
-- [AG2 Observability Example](https://docs.ag2.ai/notebooks/agentchat_agentops)
-- [AG2 - AgentOps Documentation](https://docs.ag2.ai/docs/ecosystem/agentops)
+- [AG2 Observability Example](https://github.com/ag2ai/ag2/blob/main/notebook/agentchat_agentops.ipynb)
+- [AG2 - AgentOps Documentation](https://docs.ag2.ai/latest/docs/ecosystem/agentops/)
 
 ### Camel AI 🐪
 
@@ -845,6 +845,7 @@ Check out our growth in the community:
 |<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/134388954?s=40&v=4" width="20" height="20" alt="">  &nbsp; [camel-ai](https://github.com/camel-ai) / [camel](https://github.com/camel-ai/camel) | 5166 |
 |<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/152537519?s=40&v=4" width="20" height="20" alt="">  &nbsp; [superagent-ai](https://github.com/superagent-ai) / [superagent](https://github.com/superagent-ai/superagent) | 5050 |
 |<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/30197649?s=40&v=4" width="20" height="20" alt="">  &nbsp; [iyaja](https://github.com/iyaja) / [llama-fs](https://github.com/iyaja/llama-fs) | 4713 |
+|<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/188122941?s=40&v=4" width="20" height="20" alt="">  &nbsp; [ag2ai](https://github.com/ag2ai) / [ag2](https://github.com/ag2ai/ag2) | 4240 |
 |<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/162546372?s=40&v=4" width="20" height="20" alt="">  &nbsp; [BasedHardware](https://github.com/BasedHardware) / [Omi](https://github.com/BasedHardware/Omi) | 2723 |
 |<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/454862?s=40&v=4" width="20" height="20" alt="">  &nbsp; [MervinPraison](https://github.com/MervinPraison) / [PraisonAI](https://github.com/MervinPraison/PraisonAI) | 2007 |
 |<img class="avatar mr-2" src="https://avatars.githubusercontent.com/u/140554352?s=40&v=4" width="20" height="20" alt="">  &nbsp; [AgentOps-AI](https://github.com/AgentOps-AI) / [Jaiqu](https://github.com/AgentOps-AI/Jaiqu) | 272 |

--- a/docs/v2/integrations/ag2.mdx
+++ b/docs/v2/integrations/ag2.mdx
@@ -3,6 +3,8 @@ title: AG2
 description: "Track and analyze your AG2 agents with AgentOps"
 ---
 
+[AG2](https://ag2.ai/) (formerly AutoGen) is a framework for building multi-agent conversational AI systems. AgentOps provides seamless, automatic instrumentation for AG2 — just call `agentops.init()` and all agent interactions are tracked.
+
 ## Installation
 
 <CodeGroup>
@@ -110,6 +112,20 @@ user_proxy.initiate_chat(
   </Card>
   <Card title="Wikipedia Search Tool" icon="notebook" href="https://github.com/AgentOps-AI/agentops/blob/main/examples/ag2/tools_wikipedia_search.ipynb" newTab={true}>
     Example of AG2 agents using a Wikipedia search tool.
+  </Card>
+  <Card title="Multi-Agent Group Chat" icon="notebook" href="https://github.com/AgentOps-AI/agentops/blob/main/examples/ag2/groupchat.py" newTab={true}>
+    Orchestrate a team of specialized agents (researcher, coder, critic) with full AgentOps tracing.
+  </Card>
+</CardGroup>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="AG2 - AgentOps Ecosystem Docs" icon="book" href="https://docs.ag2.ai/latest/docs/ecosystem/agentops/" newTab={true}>
+    Official AG2 documentation on integrating with AgentOps.
+  </Card>
+  <Card title="AG2 OpenTelemetry Tracing" icon="blog" href="https://docs.ag2.ai/latest/docs/blog/2026/02/08/AG2-OpenTelemetry-Tracing/" newTab={true}>
+    Full observability for multi-agent systems with AG2's built-in tracing.
   </Card>
 </CardGroup>
 

--- a/llms.txt
+++ b/llms.txt
@@ -155,8 +155,8 @@ pip install 'crewai[agentops]'
 ### AG2 
 With only two lines of code, add full observability and monitoring to AG2 (formerly AutoGen) agents. Set an `AGENTOPS_API_KEY` in your environment and call `agentops.init()`
 
-- [AG2 Observability Example](https://docs.ag2.ai/notebooks/agentchat_agentops)
-- [AG2 - AgentOps Documentation](https://docs.ag2.ai/docs/ecosystem/agentops)
+- [AG2 Observability Example](https://github.com/ag2ai/ag2/blob/main/notebook/agentchat_agentops.ipynb)
+- [AG2 - AgentOps Documentation](https://docs.ag2.ai/latest/docs/ecosystem/agentops/)
 
 ### Camel AI 
 


### PR DESCRIPTION
- Fix broken links to AG2 documentation (docs.ag2.ai/notebooks/agentchat_agentops and docs.ag2.ai/docs/ecosystem/agentops both return 404) in README.md and llms.txt
- Improve AG2 integration page: add intro paragraph, group chat example, and Resources section with links to AG2's ecosystem docs and OpenTelemetry tracing blog
- Add AG2 to "Popular projects using AgentOps" table in README


Testing: verified that links resolve correctly.