### PR TITLE
fix: add None checks for optional tool fields in response attributes

### DIFF
--- a/agentops/instrumentation/providers/openai/attributes/response.py
+++ b/agentops/instrumentation/providers/openai/attributes/response.py
@@ -503,7 +503,7 @@ def get_response_tool_web_search_attributes(tool: "WebSearchTool", index: int) -
     if hasattr(tool, "search_context_size"):
         parameters["search_context_size"] = tool.search_context_size
 
-    if hasattr(tool, "user_location"):
+    if hasattr(tool, "user_location") and tool.user_location is not None:
         parameters["user_location"] = tool.user_location.__dict__
 
     tool_data = tool.__dict__
@@ -521,13 +521,13 @@ def get_response_tool_file_search_attributes(tool: "FileSearchTool", index: int)
     if hasattr(tool, "vector_store_ids"):
         parameters["vector_store_ids"] = tool.vector_store_ids
 
-    if hasattr(tool, "filters"):
+    if hasattr(tool, "filters") and tool.filters is not None:
         parameters["filters"] = tool.filters.__dict__
 
     if hasattr(tool, "max_num_results"):
         parameters["max_num_results"] = tool.max_num_results
 
-    if hasattr(tool, "ranking_options"):
+    if hasattr(tool, "ranking_options") and tool.ranking_options is not None:
         parameters["ranking_options"] = tool.ranking_options.__dict__
 
     tool_data = tool.__dict__


### PR DESCRIPTION
## Summary
- Adds `is not None` checks before accessing `.__dict__` on optional tool fields
- Fixes `AttributeError: 'NoneType' object has no attribute '__dict__'` when using OpenAI Agents SDK with web search or file search tools

## Problem
`WebSearchTool.user_location`, `FileSearchTool.filters`, and `FileSearchTool.ranking_options` are optional fields that default to `None` in the OpenAI SDK. The existing `hasattr()` guards return `True` even when the attribute value is `None`, causing the `.__dict__` access to crash.

## Changes
In `agentops/instrumentation/providers/openai/attributes/response.py`:
- `get_response_tool_web_search_attributes`: Added `and tool.user_location is not None`
- `get_response_tool_file_search_attributes`: Added `and tool.filters is not None` and `and tool.ranking_options is not None`

## Test plan
- [ ] Verify web search tool with `user_location=None` no longer crashes
- [ ] Verify file search tool with `filters=None` and `ranking_options=None` no longer crashes
- [ ] Verify tools with non-None values still extract attributes correctly

Fixes #1285

https://claude.ai/code/session_011TWMvnjeLgAJg9XtxoLfZT