### PR TITLE
fix: add None checks before accessing __dict__ on optional tool fields

### DIFF
--- a/agentops/instrumentation/providers/openai/attributes/response.py
+++ b/agentops/instrumentation/providers/openai/attributes/response.py
@@ -503,7 +503,7 @@ def get_response_tool_web_search_attributes(tool: "WebSearchTool", index: int) -
     if hasattr(tool, "search_context_size"):
         parameters["search_context_size"] = tool.search_context_size
 
-    if hasattr(tool, "user_location"):
+    if hasattr(tool, "user_location") and tool.user_location is not None:
         parameters["user_location"] = tool.user_location.__dict__
 
     tool_data = tool.__dict__
@@ -521,13 +521,13 @@ def get_response_tool_file_search_attributes(tool: "FileSearchTool", index: int)
     if hasattr(tool, "vector_store_ids"):
         parameters["vector_store_ids"] = tool.vector_store_ids
 
-    if hasattr(tool, "filters"):
+    if hasattr(tool, "filters") and tool.filters is not None:
         parameters["filters"] = tool.filters.__dict__
 
     if hasattr(tool, "max_num_results"):
         parameters["max_num_results"] = tool.max_num_results
 
-    if hasattr(tool, "ranking_options"):
+    if hasattr(tool, "ranking_options") and tool.ranking_options is not None:
         parameters["ranking_options"] = tool.ranking_options.__dict__
 
     tool_data = tool.__dict__


### PR DESCRIPTION
## Problem

When using OpenAI Agents SDK with file search or web search tools, on_span_end raises:

```
AttributeError: NoneType object has no attribute __dict__
```

The root cause: hasattr() returns True even when the attribute exists but is None. Then accessing .__dict__ on None crashes.

Affected locations in response.py:
- tool.user_location.__dict__ (line ~506)
- tool.filters.__dict__ (line ~524)
- tool.ranking_options.__dict__ (line ~530)

## Fix

Add is not None checks alongside hasattr():

```python
# Before
if hasattr(tool, "user_location"):    parameters["user_location"] = tool.user_location.__dict__
# After
if hasattr(tool, "user_location") and tool.user_location is not None:
    parameters["user_location"] = tool.user_location.__dict__
```