### PR TITLE
fix(langgraph): forward *args/**kwargs through node wrappers to preserve config kwarg

### DIFF
--- a/agentops/instrumentation/agentic/langgraph/instrumentation.py
+++ b/agentops/instrumentation/agentic/langgraph/instrumentation.py
@@ -364,8 +364,11 @@ class LanggraphInstrumentor(BaseInstrumentor):
             if inspect.iscoroutinefunction(original_func):
 
                 @wraps(original_func)
-                async def wrapped_node_async(state):
+                async def wrapped_node_async(*args, **kwargs):
                     # Track node execution in parent graph span
+                    # LangGraph passes state as the first positional arg; additional
+                    # kwargs (e.g. config: RunnableConfig) are forwarded transparently.
+                    state = args[0] if args else kwargs.get("state")
                     self._track_node_execution(key)
 
                     # Check if this node contains an LLM call
@@ -385,8 +388,8 @@ class LanggraphInstrumentor(BaseInstrumentor):
                             )
 
                             try:
-                                # Call the original function
-                                result = await original_func(state)
+                                # Forward all args so that optional kwargs like config are preserved
+                                result = await original_func(*args, **kwargs)
 
                                 # Extract LLM information from the result
                                 self._extract_llm_info_from_result(span, state, result)
@@ -399,12 +402,15 @@ class LanggraphInstrumentor(BaseInstrumentor):
                                 raise
                     else:
                         # Non-LLM node, just execute normally
-                        return await original_func(state)
+                        return await original_func(*args, **kwargs)
             else:
 
                 @wraps(original_func)
-                def wrapped_node_sync(state):
+                def wrapped_node_sync(*args, **kwargs):
                     # Track node execution in parent graph span
+                    # LangGraph passes state as the first positional arg; additional
+                    # kwargs (e.g. config: RunnableConfig) are forwarded transparently.
+                    state = args[0] if args else kwargs.get("state")
                     self._track_node_execution(key)
 
                     # Check if this node contains an LLM call
@@ -423,8 +429,8 @@ class LanggraphInstrumentor(BaseInstrumentor):
                             )
 
                             try:
-                                # Call the original function
-                                result = original_func(state)
+                                # Forward all args so that optional kwargs like config are preserved
+                                result = original_func(*args, **kwargs)
 
                                 # Extract LLM information from the result
                                 self._extract_llm_info_from_result(span, state, result)
@@ -437,7 +443,7 @@ class LanggraphInstrumentor(BaseInstrumentor):
                                 raise
                     else:
                         # Non-LLM node, just execute normally
-                        return original_func(state)
+                        return original_func(*args, **kwargs)
 
                 return wrapped_node_sync
 


### PR DESCRIPTION
## Problem

LangGraph node functions may accept a second argument `config: RunnableConfig`:

```python
from langchain_core.runnables import RunnableConfig

def agent_node(state: AgentState, config: RunnableConfig):
    response = model.invoke(state["messages"], config=config)
    return {"messages": [response]}
```

When AgentOps instruments the graph via `_wrap_add_node`, both `wrapped_node_async` and `wrapped_node_sync` use a hard-coded `(state)` signature:

```python
async def wrapped_node_async(state):      # ← only accepts state
    ...
    result = await original_func(state)   # ← drops config
```

LangGraph calls the node with `config=...` as a keyword argument, but the wrapper doesn't accept it, raising:

```
TypeError: agent_node() got an unexpected keyword argument 'config'
```

## Fix

Change both `wrapped_node_async` and `wrapped_node_sync` to `(*args, **kwargs)` and forward them to the original function:

```python
async def wrapped_node_async(*args, **kwargs):
    state = args[0] if args else kwargs.get("state")
    ...
    result = await original_func(*args, **kwargs)  # forwards config and anything else
```

This is transparent — nodes that only accept `state` continue to work exactly as before. Nodes that also accept `config` (or any future LangGraph-injected arguments) now work correctly.

Fixes #1295

## Test plan

- [ ] Node function with `def agent_node(state, config: RunnableConfig)` no longer raises `TypeError` when AgentOps is active
- [ ] Standard `def agent_node(state)` nodes continue to work normally
- [ ] Async node variants work the same way