### PR TITLE
fix: support openai SDK v2 — wrap parse() on non-beta path, isolate wrapper errors

### DIFF
--- a/agentops/instrumentation/providers/openai/instrumentor.py
+++ b/agentops/instrumentation/providers/openai/instrumentor.py
@@ -92,11 +92,8 @@ class OpenaiInstrumentor(CommonInstrumentor):
     def _custom_wrap(self, **kwargs):
         """Add custom wrappers for streaming functionality."""
         if is_openai_v1() and self._tracer:
-            # from wrapt import wrap_function_wrapper
-            # # Add streaming wrappers for v1
+            # Chat completion streaming wrappers (create)
             try:
-                # Chat completion streaming wrappers
-
                 wrap_function_wrapper(
                     "openai.resources.chat.completions",
                     "Completions.create",
@@ -108,21 +105,45 @@ class OpenaiInstrumentor(CommonInstrumentor):
                     "AsyncCompletions.create",
                     async_chat_completion_stream_wrapper(self._tracer),
                 )
+            except Exception as e:
+                logger.warning(f"[OPENAI INSTRUMENTOR] Error wrapping chat.completions.create: {e}")
 
-                # Beta chat completion streaming wrappers
+            # Chat completion parse wrappers — try the current SDK path first,
+            # then fall back to the legacy beta path used in openai < 2.0.
+            _parse_wrapped = False
+            try:
                 wrap_function_wrapper(
-                    "openai.resources.beta.chat.completions",
+                    "openai.resources.chat.completions",
                     "Completions.parse",
                     chat_completion_stream_wrapper(self._tracer),
                 )
-
                 wrap_function_wrapper(
-                    "openai.resources.beta.chat.completions",
+                    "openai.resources.chat.completions",
                     "AsyncCompletions.parse",
                     async_chat_completion_stream_wrapper(self._tracer),
                 )
+                _parse_wrapped = True
+            except Exception:
+                pass
 
-                # Responses API streaming wrappers
+            if not _parse_wrapped:
+                # Legacy path: openai < 2.0 exposed .parse() under beta.chat.completions
+                try:
+                    wrap_function_wrapper(
+                        "openai.resources.beta.chat.completions",
+                        "Completions.parse",
+                        chat_completion_stream_wrapper(self._tracer),
+                    )
+                    wrap_function_wrapper(
+                        "openai.resources.beta.chat.completions",
+                        "AsyncCompletions.parse",
+                        async_chat_completion_stream_wrapper(self._tracer),
+                    )
+                except Exception as e:
+                    logger.debug(f"[OPENAI INSTRUMENTOR] beta.chat.completions.parse not available: {e}")
+
+            # Responses API streaming wrappers
+            try:
                 wrap_function_wrapper(
                     "openai.resources.responses",
                     "Responses.create",
@@ -135,7 +156,7 @@ class OpenaiInstrumentor(CommonInstrumentor):
                     async_responses_stream_wrapper(self._tracer),
                 )
             except Exception as e:
-                logger.warning(f"[OPENAI INSTRUMENTOR] Error setting up OpenAI streaming wrappers: {e}")
+                logger.warning(f"[OPENAI INSTRUMENTOR] Error wrapping responses API: {e}")
         else:
             if not is_openai_v1():
                 logger.debug("[OPENAI INSTRUMENTOR] Skipping custom wrapping - not using OpenAI v1")


### PR DESCRIPTION
## Problem

In openai >= 2.0, the structured output `.parse()` method moved from `openai.resources.beta.chat.completions` to `openai.resources.chat.completions`. The current instrumentor always tries the beta path, which raises `ModuleNotFoundError: No module named 'openai.resources.beta.chat'` on newer SDK versions.

A secondary issue: all wrappers are in a single `try/except`, so when the beta path fails, the Responses API wrappers (`openai.resources.responses`) are silently skipped too — meaning users on openai v2 lose both structured output tracing and Responses API tracing.

Closes #1260

## Changes

- **Try `chat.completions.parse` first** (current SDK location in openai >= 2.0)
- **Fall back to `beta.chat.completions.parse`** for backwards compatibility with openai < 2.0
- **Split into separate `try/except` blocks** so a failure in one wrapper group (e.g. beta path) doesn't prevent other wrappers from being installed

## Testing

Install `agentops` with `openai >= 2.0` and verify:
1. No `[OPENAI INSTRUMENTOR] Error setting up OpenAI streaming wrappers: No module named 'openai.resources.beta.chat'` warning on startup
2. Structured output calls using `.parse()` are traced correctly
3. Responses API calls are traced correctly

Also tested with `openai < 2.0` to confirm backwards compatibility via the legacy beta fallback path.