### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.3.0
+      - uses: Jwrede/tokentoll@v0.4.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,17 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@v0.3.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.4.0
+      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc
+      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2
+      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,0 +1,1 @@
+default_model: gpt-4o

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,1 +1,0 @@
-default_model: gpt-4o


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `app/e2e/sdk-api/src/agents/basic_agent.py` | 25 | openai | gpt-3.5-turbo | $0.001539 | $1.54 |
| `app/e2e/sdk-api/src/agents/basic_agent.py` | 36 | openai | gpt-3.5-turbo | $0.001539 | $1.54 |
| `app/e2e/sdk-api/src/agents/basic_agent.py` | 48 | openai | gpt-3.5-turbo | $0.001538 | $1.54 |
| `app/e2e/sdk-api/src/agents/basic_agent.py` | 61 | openai | gpt-3.5-turbo | $0.001540 | $1.54 |
| `app/e2e/sdk-api/src/agents/basic_agent.py` | 72 | openai | gpt-3.5-turbo | $0.001540 | $1.54 |
| `examples/anthropic/agentops-anthropic-understanding-tools.py` | 104 | anthropic | claude-3-7-sonnet-20250219 | $0.08 | $76.50 |
| `examples/anthropic/agentops-anthropic-understanding-tools.py` | 150 | anthropic | claude-3-7-sonnet-20250219 | $0.08 | $76.50 |
| `examples/anthropic/agentops-anthropic-understanding-tools.py` | 264 | anthropic | claude-3-7-sonnet-20250219 | $0.08 | $76.50 |
| `examples/anthropic/agentops-anthropic-understanding-tools.py` | 345 | anthropic | claude-3-7-sonnet-20250219 | $0.08 | $76.50 |
| `examples/anthropic/anthropic-example-async.py` | 49 | anthropic | claude-3-7-sonnet-20250219 | $0.02 | $15.82 |
| `examples/anthropic/anthropic-example-sync.py` | 80 | anthropic | claude-3-7-sonnet-20250219 | $0.04 | $36.20 |
| `examples/google_genai/gemini_example.py` | 23 | google_genai | gemini-1.5-flash | $0.000001 | $0.000600 |
| `examples/google_genai/gemini_example.py` | 28 | google_genai | gemini-1.5-flash | $0.000001 | $0.000825 |
| `examples/google_genai/gemini_example.py` | 38 | google_genai | gemini-1.5-flash | $0.000001 | $0.000900 |
| `examples/langchain/langchain_examples.py` | 38 | langchain | gpt-3.5-turbo | $0.001786 | $1.79 |
| `examples/langgraph/langgraph_example.py` | 50 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/litellm/litellm_example.py` | 49 | litellm | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/openai/multi_tool_orchestration.py` | 58 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `examples/openai/multi_tool_orchestration.py` | 145 | openai | gpt-4o | $0.04 | $42.21 |
| `examples/openai/multi_tool_orchestration.py` | 282 | openai | gpt-4o | $0.04 | $42.21 |
| `examples/openai/multi_tool_orchestration.py` | 340 | openai | gpt-4o | $0.04 | $42.21 |
| `examples/openai/multi_tool_orchestration.py` | 207 | openai | gpt-4o | $0.04 | $42.21 |
| `examples/openai/multi_tool_orchestration.py` | 90 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `examples/openai/multi_tool_orchestration.py` | 249 | openai | gpt-4o | $0.04 | $42.21 |
| `examples/openai/multi_tool_orchestration.py` | 113 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `examples/openai/multi_tool_orchestration.py` | 137 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `examples/openai/o3_responses_example.py` | 116 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `examples/openai/o3_responses_example.py` | 163 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `examples/openai/o3_responses_example.py` | 260 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `examples/openai/o3_responses_example.py` | 307 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `examples/openai/openai_example_async.py` | 57 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/openai/openai_example_async.py` | 71 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/openai/openai_example_sync.py` | 45 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/openai/openai_example_sync.py` | 55 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `examples/openai/web_search.py` | 37 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `examples/openai/web_search.py` | 49 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `examples/openai/web_search.py` | 53 | openai | gpt-4o-mini | $0.002460 | $2.46 |
| `examples/openai/web_search.py` | 66 | openai | gpt-4o | $0.04 | $40.98 |
| `examples/openai/web_search.py` | 82 | openai | gpt-4o | $0.04 | $42.21 |
| `examples/xai/grok_examples.py` | 68 | openai | grok-3-mini | $0.04 | $41.62 |
| `examples/xai/grok_vision_examples.py` | 56 | openai | grok-2-vision-1212 | $0.04 | $40.96 |
| `examples/xpander/coding_agent.py` | 73 | openai | gpt-4.1 | $0.07 | $66.54 |
| `tests/core_manual_tests/benchmark.py` | 12 | openai | gpt-3.5-turbo | $0.001543 | $1.54 |
| `tests/core_manual_tests/canary.py` | 13 | openai | gpt-3.5-turbo | $0.001786 | $1.79 |
| `tests/core_manual_tests/multi_session_llm.py` | 28 | openai | gpt-3.5-turbo | $0.001786 | $1.79 |
| `tests/core_manual_tests/providers/anthropic_canary.py` | 12 | anthropic | claude-3-5-sonnet-20240620 | $0.02 | $15.37 |
| `tests/core_manual_tests/providers/anthropic_canary.py` | 24 | anthropic | claude-3-5-sonnet-20240620 | $0.02 | $15.38 |
| `tests/core_manual_tests/providers/anthropic_canary.py` | 62 | anthropic | claude-3-5-sonnet-20240620 | $0.02 | $15.38 |
| `tests/core_manual_tests/providers/anthropic_canary.py` | 45 | anthropic | claude-3-5-sonnet-20240620 | $0.02 | $15.38 |
| `tests/core_manual_tests/providers/litellm_canary.py` | 10 | litellm | gpt-3.5-turbo | $0.001540 | $1.54 |
| `tests/core_manual_tests/providers/litellm_canary.py` | 12 | litellm | gpt-3.5-turbo | $0.001540 | $1.54 |
| `tests/core_manual_tests/providers/litellm_canary.py` | 34 | litellm | gpt-3.5-turbo | $0.001540 | $1.54 |
| `tests/core_manual_tests/providers/litellm_canary.py` | 23 | litellm | gpt-3.5-turbo | $0.001540 | $1.54 |
| `tests/core_manual_tests/providers/openai_canary.py` | 12 | openai | gpt-3.5-turbo | $0.001537 | $1.54 |
| `tests/core_manual_tests/providers/openai_canary.py` | 18 | openai | gpt-3.5-turbo | $0.001538 | $1.54 |
| `tests/core_manual_tests/providers/openai_canary.py` | 28 | openai | gpt-3.5-turbo | $0.001538 | $1.54 |
| `tests/core_manual_tests/providers/openai_canary.py` | 36 | openai | gpt-3.5-turbo | $0.001538 | $1.54 |
| `tests/smoke/test_openai.py` | 11 | openai | gpt-3.5-turbo | $0.001539 | $1.54 |
| `tests/unit/instrumentation/fixtures/generate_anthropic_fixtures.py` | 33 | anthropic | claude-3-opus-20240229 | $0.007620 | $7.62 |
| `tests/unit/instrumentation/fixtures/generate_anthropic_fixtures.py` | 41 | anthropic | claude-3-opus-20240229 | $0.007725 | $7.73 |
| `tests/unit/instrumentation/fixtures/generate_anthropic_fixtures.py` | 50 | anthropic | claude-3-opus-20240229 | $0.007995 | $8.00 |
| `tests/unit/instrumentation/fixtures/generate_anthropic_fixtures.py` | 63 | anthropic | claude-3-opus-20240229 | $0.007650 | $7.65 |
| `tests/unit/instrumentation/fixtures/generate_anthropic_fixtures.py` | 74 | anthropic | claude-3-opus-20240229 | $0.007650 | $7.65 |

**Total estimated monthly cost: $1163.61**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
