### PR TITLE
feat: add Astraflow provider example (OpenAI-compatible)

### DIFF
--- a/examples/astraflow/README.md
+++ b/examples/astraflow/README.md
@@ -1,0 +1,30 @@
+# Astraflow Examples with AgentOps
+
+This directory contains examples of using [Astraflow](https://www.umodelverse.ai/) (UCloud / 优刻得 umodelverse) with AgentOps instrumentation.
+
+Astraflow is an OpenAI-compatible AI model aggregation platform that provides access to 200+ models through a single API. Because it is OpenAI-compatible, you can use the standard OpenAI Python client by simply pointing it at the Astraflow `base_url`, and AgentOps' built-in OpenAI instrumentation will automatically track every call.
+
+## Prerequisites
+
+- Python >= 3.10 < 3.13
+- Install required dependencies:
+  ```
+  pip install agentops openai python-dotenv
+  ```
+- Set the appropriate environment variable for your region:
+  - **Global endpoint** — `ASTRAFLOW_API_KEY` (base URL: `https://api-us-ca.umodelverse.ai/v1`)
+  - **China endpoint** — `ASTRAFLOW_CN_API_KEY` (base URL: `https://api.modelverse.cn/v1`)
+
+## Examples
+
+### Astraflow Example
+
+File: `astraflow_example.py`
+
+Demonstrates basic chat completion usage against Astraflow via the OpenAI client, with full AgentOps tracing.
+
+## AgentOps Integration
+
+These examples show how to use AgentOps to monitor and analyze your AI applications. Because Astraflow is OpenAI-compatible, AgentOps automatically instruments your Astraflow calls through its existing OpenAI integration — no extra configuration required.
+
+To learn more about AgentOps, visit [https://www.agentops.ai](https://www.agentops.ai)

--- a/examples/astraflow/astraflow_example.py
+++ b/examples/astraflow/astraflow_example.py
@@ -1,0 +1,68 @@
+# Astraflow Example
+#
+# This example demonstrates how to use Astraflow (UCloud / 优刻得 umodelverse) with AgentOps via the OpenAI Python client.
+#
+# Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
+# Because it is OpenAI-compatible, AgentOps' built-in OpenAI instrumentation automatically
+# tracks every Astraflow call once you point the OpenAI client at the Astraflow base_url.
+#
+# Endpoints:
+#   - Global: https://api-us-ca.umodelverse.ai/v1   (env: ASTRAFLOW_API_KEY)
+#   - China:  https://api.modelverse.cn/v1          (env: ASTRAFLOW_CN_API_KEY)
+#
+# First let's install the required packages
+# %pip install -U openai
+# %pip install -U agentops
+# %pip install -U python-dotenv
+from openai import OpenAI
+import agentops
+import os
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+os.environ["AGENTOPS_API_KEY"] = os.getenv("AGENTOPS_API_KEY", "your_api_key_here")
+
+# Initialize the AgentOps client
+agentops.init(
+    auto_start_session=False,
+    trace_name="Astraflow Example",
+    tags=["astraflow", "agentops-example"],
+)
+tracer = agentops.start_trace(
+    trace_name="Astraflow Example", tags=["astraflow-example", "agentops-example"]
+)
+
+# Pick an Astraflow endpoint. Default to the global endpoint; switch to the China
+# endpoint by setting ASTRAFLOW_CN_API_KEY instead of ASTRAFLOW_API_KEY.
+if os.getenv("ASTRAFLOW_CN_API_KEY"):
+    base_url = "https://api.modelverse.cn/v1"
+    api_key = os.getenv("ASTRAFLOW_CN_API_KEY")
+else:
+    base_url = "https://api-us-ca.umodelverse.ai/v1"
+    api_key = os.getenv("ASTRAFLOW_API_KEY", "your_astraflow_api_key_here")
+
+# Initialize the OpenAI client pointed at Astraflow
+client = OpenAI(base_url=base_url, api_key=api_key)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me a fun fact about observability for AI agents."},
+    ],
+)
+
+print(response.choices[0].message.content)
+
+agentops.end_trace(tracer, end_state="Success")
+
+# Verify spans were recorded
+print("\n" + "=" * 50)
+print("Now let's verify that our LLM calls were tracked properly...")
+try:
+    agentops.validate_trace_spans(trace_context=tracer)
+    print("\n✅ Success! All LLM spans were properly recorded in AgentOps.")
+except agentops.ValidationError as e:
+    print(f"\n❌ Error validating spans: {e}")
+    raise

--- a/examples/astraflow/requirements.txt
+++ b/examples/astraflow/requirements.txt
@@ -1,0 +1,3 @@
+openai  # Astraflow is OpenAI-compatible and uses the OpenAI client
+agentops
+python-dotenv


### PR DESCRIPTION
## Summary

Adds support for [Astraflow](https://www.umodelverse.ai/) (UCloud / 优刻得 umodelverse), an OpenAI-compatible AI model aggregation platform supporting 200+ models.

Because Astraflow is OpenAI-compatible, AgentOps' existing OpenAI instrumentation automatically tracks every Astraflow call when the OpenAI client is pointed at the Astraflow `base_url`. No new instrumentor or registration in `agentops/instrumentation/__init__.py` is required — this mirrors how the existing **xAI / Grok** integration works in this repo (`examples/xai/`).

## Endpoints

| Region | Base URL | Env var |
| --- | --- | --- |
| Global | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China  | `https://api.modelverse.cn/v1`        | `ASTRAFLOW_CN_API_KEY` |

## Changes

Adds a new example directory `examples/astraflow/`, mirroring the existing `examples/xai/` pattern exactly:

- `examples/astraflow/astraflow_example.py` — minimal chat completion example via the OpenAI client + AgentOps tracing, auto-selects global vs. China endpoint based on which env var is set.
- `examples/astraflow/requirements.txt` — `openai`, `agentops`, `python-dotenv`.
- `examples/astraflow/README.md` — usage instructions.

No changes to the SDK itself — minimum viable integration.

## Testing

Run the example after exporting `AGENTOPS_API_KEY` and `ASTRAFLOW_API_KEY`:

```bash
python examples/astraflow/astraflow_example.py
```

The example calls `agentops.validate_trace_spans()` at the end to confirm spans are recorded.
