### PR TITLE
feat: add MCP trust verification example with AgentOps monitoring

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,59 @@
+# MCP Agent Trust Verification + AgentOps Monitoring
+
+An example showing how to monitor an MCP-powered Solana agent trust
+verification workflow using [AgentOps](https://agentops.ai).
+
+## What It Does
+
+1. Calls the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server to score
+   a Solana wallet (`score_agent`) and run a preflight check (`preflight_check`)
+2. Gates downstream requests to OpenAI behind the trust check (wallets with
+   score ≥ 0.5 and `APPROVE` preflight proceed; others are rejected)
+3. Records every step as an AgentOps span — trust score, preflight decision,
+   and OpenAI response — searchable in the AgentOps dashboard
+
+## Setup
+
+```bash
+pip install agentops mcp openai python-dotenv
+```
+
+```bash
+export AGENTOPS_API_KEY=your_key   # from app.agentops.ai
+export OPENAI_API_KEY=your_key
+```
+
+## Run
+
+```bash
+python mcp_trust_verification.py
+```
+
+View traces at [app.agentops.ai](https://app.agentops.ai).
+
+## MCP Server
+
+| Tool | Description | Cost |
+|------|-------------|------|
+| `score_agent` | Trust score (0–1) + x402 payment history | Free |
+| `preflight_check` | APPROVE/REJECT with reasoning | Free |
+| `get_trust_receipt` | Signed on-chain trust receipt | HTTP 402 |
+
+```json
+{
+  "mcpServers": {
+    "twzrd-agent-intel": {
+      "url": "https://intel.twzrd.xyz/mcp"
+    }
+  }
+}
+```
+
+## AgentOps Dashboard
+
+The example creates tagged traces with `mcp`, `twzrd`, `solana`, and
+`trust-verification` tags. Each trace includes:
+
+- `trust_verification` action with wallet address, score, and preflight result
+- Downstream OpenAI call (if wallet is approved)
+- End state: `Success` (approved + responded) or `Rejected` (low trust score)

--- a/examples/mcp/mcp_trust_verification.py
+++ b/examples/mcp/mcp_trust_verification.py
@@ -1,0 +1,139 @@
+# # MCP Agent Trust Verification with AgentOps Monitoring
+#
+# This example shows how to monitor an MCP-powered agent that verifies
+# Solana wallet trustworthiness using the TWZRD Agent Intel MCP server.
+#
+# AgentOps traces every MCP tool call (score_agent, preflight_check)
+# alongside the agent's decisions, giving you full observability over
+# your trust-gating logic.
+#
+# Requirements:
+# %pip install agentops mcp openai python-dotenv
+
+import asyncio
+import os
+import agentops
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MCP_URL = "https://intel.twzrd.xyz/mcp"
+TRUST_THRESHOLD = 0.5
+
+agentops.init(
+    api_key=os.getenv("AGENTOPS_API_KEY", "your_agentops_api_key"),
+    auto_start_session=False,
+    trace_name="TWZRD MCP Trust Check",
+)
+
+openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", "your_openai_api_key"))
+
+
+async def call_twzrd_mcp(tool_name: str, wallet: str) -> str:
+    """Call a TWZRD Agent Intel MCP tool and return the result."""
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, {"wallet": wallet})
+            return result.content[0].text
+
+
+def verify_agent_wallet(wallet: str) -> dict:
+    """
+    Verify a Solana agent wallet using TWZRD Agent Intel.
+
+    AgentOps records this function call as a span with the wallet address,
+    trust score, and preflight decision — searchable in your dashboard.
+
+    Args:
+        wallet: Solana wallet address (base58)
+
+    Returns:
+        dict with trust_score, preflight_result, and approved flag
+    """
+    score_raw = asyncio.run(call_twzrd_mcp("score_agent", wallet))
+    preflight_raw = asyncio.run(call_twzrd_mcp("preflight_check", wallet))
+
+    # Parse score from response
+    import re
+    score_match = re.search(r"(\d+\.\d+|\d+)", score_raw)
+    trust_score = float(score_match.group(1)) if score_match else 0.0
+
+    approved = trust_score >= TRUST_THRESHOLD and "APPROVE" in preflight_raw.upper()
+
+    return {
+        "wallet": wallet,
+        "trust_score": trust_score,
+        "preflight_result": preflight_raw,
+        "approved": approved,
+    }
+
+
+def run_trust_gated_agent(wallet: str, user_request: str) -> str:
+    """
+    An agent that gates responses behind TWZRD wallet trust verification.
+    All steps are traced by AgentOps for monitoring and debugging.
+    """
+    tracer = agentops.start_trace(
+        trace_name=f"trust_check_{wallet[:8]}",
+        tags=["mcp", "twzrd", "solana", "trust-verification"],
+    )
+
+    try:
+        # Step 1: Verify wallet trust
+        print(f"Verifying wallet: {wallet}")
+        trust_data = verify_agent_wallet(wallet)
+        agentops.record(agentops.ActionEvent(
+            action_type="trust_verification",
+            params={"wallet": wallet},
+            returns=trust_data,
+        ))
+
+        if not trust_data["approved"]:
+            result = (
+                f"Request rejected. Wallet {wallet[:8]}... has trust score "
+                f"{trust_data['trust_score']:.2f} (threshold: {TRUST_THRESHOLD}). "
+                f"Preflight: {trust_data['preflight_result']}"
+            )
+            agentops.end_trace(tracer, end_state="Rejected")
+            return result
+
+        # Step 2: Process verified request via OpenAI
+        print(f"Wallet approved (score: {trust_data['trust_score']:.2f}). Processing request...")
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are an AI assistant for verified Solana agents. "
+                    f"The requesting agent wallet {wallet} has been verified "
+                    f"with trust score {trust_data['trust_score']:.2f}."
+                ),
+            },
+            {"role": "user", "content": user_request},
+        ]
+        response = openai_client.chat.completions.create(
+            model="gpt-4o-mini", messages=messages
+        )
+        result = response.choices[0].message.content
+
+        agentops.end_trace(tracer, end_state="Success")
+        return result
+
+    except Exception as e:
+        agentops.end_trace(tracer, end_state="Fail")
+        raise
+
+
+if __name__ == "__main__":
+    # Example: high-trust wallet (many x402 payments on-chain)
+    DEMO_WALLET = "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi"
+    REQUEST = "What Solana DeFi protocols offer the highest yields right now?"
+
+    print("TWZRD Agent Trust Verification + AgentOps Monitoring")
+    print("=" * 50)
+    result = run_trust_gated_agent(DEMO_WALLET, REQUEST)
+    print(f"\nResult: {result}")
+    print("\nView traces at: https://app.agentops.ai")

--- a/examples/mcp/requirements.txt
+++ b/examples/mcp/requirements.txt
@@ -1,0 +1,4 @@
+agentops
+mcp
+openai
+python-dotenv


### PR DESCRIPTION
## Summary

Adds `examples/mcp/` — an example demonstrating AgentOps monitoring of an MCP-powered Solana agent trust verification workflow.

**What it shows:**
- Connects to the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server (streamable-HTTP) to call `score_agent` and `preflight_check` on a Solana wallet
- Gates downstream OpenAI requests behind the trust check: wallets with score ≥ 0.5 and `APPROVE` preflight proceed; others are rejected with a reason
- Records every step as an AgentOps trace — `trust_verification` action, OpenAI response, and end state (`Success`/`Rejected`) — all tagged with `mcp`, `twzrd`, `solana`

**Why it's useful:**
- Shows `agentops` monitoring a real external MCP tool call flow (not just OpenAI)
- Demonstrates trust-gating patterns: only verified on-chain agents can trigger LLM calls
- x402 (HTTP 402) paid endpoints (`get_trust_receipt`) can be metered via AgentOps for cost tracking

**Files added:**
- `examples/mcp/mcp_trust_verification.py` — full working Python script
- `examples/mcp/README.md` — setup, usage, and dashboard instructions
- `examples/mcp/requirements.txt` — dependencies

**MCP server details:**
- Endpoint: `https://intel.twzrd.xyz/mcp` (streamable-HTTP, no API key needed for free tools)
- Free tools: `score_agent(wallet)`, `preflight_check(wallet)`
- Paid tool: `get_trust_receipt(wallet)` — HTTP 402 / x402 micropayment